### PR TITLE
Fix imports in API guide

### DIFF
--- a/atlasserver/forcephot/templates/apiguide.html
+++ b/atlasserver/forcephot/templates/apiguide.html
@@ -11,7 +11,7 @@
 
     <p>First, let's import some useful packages and set the API URL:</p>
 <pre><code>import io
-import os
+import re
 import sys
 import time
 


### PR DESCRIPTION
The `os` package is not needed and the `re` package is missing.

`import os` -> `import re`