### PR TITLE
Fix bugs found in code review

### DIFF
--- a/atlasserver/atlastaskrunner.py
+++ b/atlasserver/atlastaskrunner.py
@@ -16,7 +16,7 @@ def run_command(commands: list[str], print_output: bool = True) -> int:
         commands,
         shell=False,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,  # merged, so a full stderr pipe can't deadlock the stdout read
         encoding="utf-8",
         bufsize=1,
         universal_newlines=True,
@@ -31,11 +31,9 @@ def run_command(commands: list[str], print_output: bool = True) -> int:
         except KeyboardInterrupt:
             exit_now = True
 
-    proc.wait()
-    stdout, stderr = proc.communicate()
-    if print_output:
+    stdout, _stderr = proc.communicate()
+    if print_output and stdout:
         print(stdout, end="")
-        print(stderr, end="")
 
     if exit_now:
         sys.exit(130)

--- a/atlasserver/atlaswebserver.py
+++ b/atlasserver/atlaswebserver.py
@@ -45,7 +45,7 @@ def run_command(commands: list[str], print_output: bool = True) -> int:
         commands,
         shell=False,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.STDOUT,  # merged, so a full stderr pipe can't deadlock the stdout read
         encoding="utf-8",
         bufsize=1,
         universal_newlines=True,
@@ -55,10 +55,9 @@ def run_command(commands: list[str], print_output: bool = True) -> int:
         for line in iter(proc.stdout.readline, ""):
             print(line, end="")
 
-    stdout, stderr = proc.communicate()
-    if print_output:
+    stdout, _stderr = proc.communicate()
+    if print_output and stdout:
         print(stdout, end="")
-        print(stderr, end="")
     assert proc.returncode is not None
     return proc.returncode
 
@@ -71,8 +70,9 @@ def start() -> None:
 
     print("Starting ATLAS Apache server")
 
-    if Path(".env").is_file():
-        Path(".env").chmod(0o600)
+    envfile = ATLASSERVERPATH / ".env"
+    if envfile.is_file():
+        envfile.chmod(0o600)
 
     APACHEPATH.mkdir(parents=True, exist_ok=True)
 
@@ -127,7 +127,7 @@ def start() -> None:
         time.sleep(1)
 
     while not get_httpd_pid():
-        pass
+        time.sleep(0.2)
 
     print(f"ATLAS Apache server is running with pid {get_httpd_pid()}")
 
@@ -151,7 +151,7 @@ def main() -> None:
 
         # wait for httpd process to be ended
         while get_httpd_pid():
-            pass
+            time.sleep(0.2)
 
         start()
 

--- a/atlasserver/forcephot/serializers.py
+++ b/atlasserver/forcephot/serializers.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
+from atlasserver.forcephot.models import get_mjd_min_default
 from atlasserver.forcephot.models import Task
 
 
@@ -90,7 +91,7 @@ class ForcePhotTaskSerializer(serializers.ModelSerializer):
         badchars = "'\";"
         if any(c in dict.fromkeys(badchars) for c in value):
             raise serializers.ValidationError(
-                {field: f"{prefix}Invalid mpc_name. May not contain quotes or seimicolons"}
+                {field: f"{prefix}Invalid mpc_name. May not contain quotes or semicolons"}
             )
 
         return value
@@ -150,14 +151,14 @@ class ForcePhotTaskSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(msg)
         elif attrs.get("request_type") == "IMGZIP":
             if not attrs.get("parent_task_id", False):
-                msg = "IMGZIP requests must have have a parent_task_id set to an FP task."
+                msg = "IMGZIP requests must have a parent_task_id set to an FP task."
                 raise serializers.ValidationError(msg)
             parent_task_id = attrs["parent_task_id"]
 
             try:
                 Task.objects.all().get(id=parent_task_id, request_type="FP")
             except (ObjectDoesNotExist, IndexError):
-                msg = "IMGZIP requests must have have a parent_task_id set to an FP task id."
+                msg = "IMGZIP requests must have a parent_task_id set to an FP task id."
                 raise serializers.ValidationError(msg) from None
 
         elif not attrs.get("ra", None) and not attrs.get("dec", None):
@@ -173,12 +174,13 @@ class ForcePhotTaskSerializer(serializers.ModelSerializer):
                 {"mjd_min": "mjd_min must be either None or a finite floating-point number."}
             )
 
-        if (
-            "mjd_max" in attrs
-            and attrs["mjd_max"] is not None
-            and ("mjd_min" in attrs and attrs["mjd_min"] is not None and not attrs["mjd_max"] > attrs["mjd_min"])
-        ):
-            raise serializers.ValidationError({"mjd_max": "mjd_max must be greater than mjd_min."})
+        if attrs.get("mjd_max") not in (None, ""):
+            # when mjd_min is not given, the model default (30 days ago) will be applied on save
+            mjd_min = attrs["mjd_min"] if attrs.get("mjd_min") not in (None, "") else get_mjd_min_default()
+            if not float(attrs["mjd_max"]) > float(mjd_min):
+                raise serializers.ValidationError(
+                    {"mjd_max": f"mjd_max must be greater than mjd_min ({mjd_min} was applied)."}
+                )
 
         return attrs
 

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1,8 +1,55 @@
+import itertools
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
+
+from atlasserver.forcephot.models import Task
+from atlasserver.forcephot.views import calculate_queue_positions
 
 
-# Create your tests here.
-class YourTestClass(TestCase):
-    def setup(self) -> None:
-        # Setup run before every test method.
-        pass
+class TaskQueueTests(TestCase):
+    def setUp(self) -> None:
+        self.users = [
+            get_user_model().objects.create_user(username=f"user{i}", email=f"user{i}@example.com", password=None)
+            for i in range(3)
+        ]
+
+    def test_tasklist_requires_login(self) -> None:
+        response = self.client.get(reverse("task-list"))
+        # anonymous users are redirected to the login page by the custom exception handler
+        assert response.status_code in {302, 403}
+
+    def test_queue_positions_are_round_robin(self) -> None:
+        for user in self.users:
+            for _ in range(3):
+                Task.objects.create(user=user, ra=10.0, dec=20.0)
+
+        calculate_queue_positions()
+
+        queued = list(Task.objects.filter(finishtimestamp__isnull=True).order_by("queuepos_relative"))
+        positions = [task.queuepos_relative for task in queued]
+        assert positions == list(range(9)), positions
+
+        # each pass of three consecutive positions must contain exactly one task per user
+        userids = {user.pk for user in self.users}
+        for passtasks in itertools.batched(queued, 3, strict=True):
+            assert {task.user_id for task in passtasks} == userids
+
+
+class TaskRunnerResultFileTests(TestCase):
+    def test_remove_ssostack_resultfiles(self) -> None:
+        from atlasserver.taskrunner import main as taskrunner_main
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            resultsdir = Path(tmpdir)
+            for ext in (".fits", ".jpg", ".txt"):
+                (resultsdir / f"job00042{ext}").touch()
+
+            with mock.patch.object(taskrunner_main.settings, "RESULTS_DIR", resultsdir):
+                taskrunner_main.remove_task_resultfiles(taskid=42, request_type="SSOSTACK", logfunc=lambda _msg: None)
+
+            assert not list(resultsdir.glob("job00042.*"))

--- a/atlasserver/forcephot/urls.py
+++ b/atlasserver/forcephot/urls.py
@@ -41,7 +41,7 @@ admin.site.site_title = "ATLAS Forced Photometry"
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html"), name="index"),
     path("", include(router.urls)),
-    path("queue/<str:pk>/requestimages/", views.RequestImages.as_view(), name="requestimages"),
+    path("queue/<int:pk>/requestimages/", views.RequestImages.as_view(), name="requestimages"),
     re_path(r"^register/$", views.register, name="register"),
     path("faq/", TemplateView.as_view(template_name="faq.html", extra_context={"name": "FAQ"}), name="faq"),
     path(

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -115,7 +115,11 @@ def calculate_queue_positions() -> None:
                 except ValueError:  # the task disappeared between the two queries?
                     runningtaskid = None
 
-            for i, (taskid, task_userid) in enumerate(zip(unassigned_taskids, unassigned_task_userids, strict=True)):
+            # collect the tasks not assigned in this pass rather than popping from
+            # the lists during iteration (which would skip elements)
+            remaining_taskids: list[int] = []
+            remaining_task_userids: list[int] = []
+            for taskid, task_userid in zip(unassigned_taskids, unassigned_task_userids, strict=True):
                 if task_userid not in useridsassigned_currentpass and (
                     passnum != 0 or runningtask_userid is None or (task_userid > runningtask_userid)
                 ):
@@ -125,10 +129,14 @@ def calculate_queue_positions() -> None:
                     # method 2
                     # queuepos_updates.append((task.id, queuepos))
 
-                    unassigned_taskids.pop(i)
-                    unassigned_task_userids.pop(i)
                     useridsassigned_currentpass.add(task_userid)
                     queuepos += 1
+                else:
+                    remaining_taskids.append(taskid)
+                    remaining_task_userids.append(task_userid)
+
+            unassigned_taskids = remaining_taskids
+            unassigned_task_userids = remaining_task_userids
 
             assert passnum < (2 * queuedtaskcount + 1)  # prevent infinite loop if we're failing to assign anything
 
@@ -352,7 +360,7 @@ class RequestImages(APIView):
             raise PermissionDenied
 
         try:
-            parent_task = Task.objects.get(id=pk)
+            parent_task = Task.objects.get(id=pk, request_type="FP", is_archived=False)
 
             if parent_task.user.id != request.user.id and not request.user.is_staff:
                 raise PermissionDenied
@@ -408,7 +416,7 @@ class RequestImages(APIView):
 
 @cache_page(60 * 60 * 24, cache="usagestats")
 def statscoordchart(request):
-    tasks = Task.objects.all().order_by("-timestamp")[:20000].select_related("user")
+    tasks = list(Task.objects.all().order_by("-timestamp")[:20000].select_related("user"))
 
     dictsource = {
         "ra": [tsk.ra for tsk in tasks],
@@ -584,15 +592,12 @@ def statslongterm(request):
         thirtydaytasks.filter(country_code__isnull=False)
         .exclude(country_code="XX")
         .values_list("country_code")
-        .annotate(task_count=Count("country_code"))
+        .annotate(task_count=Count("country_code"), user_count=Count("user_id", distinct=True))
         .order_by("-task_count", "country_code")[:15]
     )
 
-    def country_activeusers(country_code: str) -> int:
-        return thirtydaytasks.filter(country_code=country_code).values_list("user_id").distinct().count()
-
     dictparams["countrylist"] = [
-        (country_code_to_name(code), task_count, country_activeusers(code)) for code, task_count in countrylist
+        (country_code_to_name(code), task_count, user_count) for code, task_count, user_count in countrylist
     ]
 
     regionlist = (

--- a/atlasserver/settings.py
+++ b/atlasserver/settings.py
@@ -60,7 +60,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
 ]
 
 filecacheroot = Path("/files/atlasforced/django_cache")

--- a/atlasserver/taskrunner/atlas_gettaskimage.py
+++ b/atlasserver/taskrunner/atlas_gettaskimage.py
@@ -54,7 +54,11 @@ def main() -> None:
         fitsoutpath.unlink()
 
     # jobxxxxx.fits.jpg to jobxxxx.jpg
-    fitsoutpath.with_suffix(".fits.jpg").rename(Path(datafile).with_suffix(".jpg"))
+    jpgpath = fitsoutpath.with_suffix(".fits.jpg")
+    if jpgpath.exists():
+        jpgpath.rename(Path(datafile).with_suffix(".jpg"))
+    else:
+        print(f"ERROR: {jpgpath} was not created")
 
 
 if __name__ == "__main__":

--- a/atlasserver/taskrunner/atlas_gettaskimage_ssostack.py
+++ b/atlasserver/taskrunner/atlas_gettaskimage_ssostack.py
@@ -40,7 +40,11 @@ def main() -> None:
         )
 
     # Rename jobxxxxx.fits.jpg to jobxxxxx.jpg.
-    Path(stackedfitsfile).with_suffix(".fits.jpg").rename(Path(stackedfitsfile).with_suffix(".jpg"))
+    jpgpath = Path(stackedfitsfile).with_suffix(".fits.jpg")
+    if jpgpath.exists():
+        jpgpath.rename(Path(stackedfitsfile).with_suffix(".jpg"))
+    else:
+        print(f"ERROR: {jpgpath} was not created")
 
 
 if __name__ == "__main__":

--- a/atlasserver/taskrunner/main.py
+++ b/atlasserver/taskrunner/main.py
@@ -38,10 +38,6 @@ TASK_MAXTIME_SECONDS: int = 4 * 3600
 
 LOG_DIR: Path = Path(__file__).resolve().parent / "logs"
 
-# so that current log can be archived periodically, keep track
-# of the filename with a date, so that it can be created when the date changes
-LASTLOGFILEARCHIVED: dict[str, Path] = {}
-
 
 def mjdnow() -> float:
     """Return the current MJD."""
@@ -61,23 +57,24 @@ def log_general(msg: str, suffix: str = "", *args, **kwargs) -> None:
     if not suffix:
         print(line, *args, **kwargs)
 
-    logfile_archive = Path(LOG_DIR, f"fprunnerlog_{dtnow.year:4d}-{dtnow.month:02d}-{dtnow.day:02d}{suffix}.txt")
     logfile_latest = Path(LOG_DIR, f"fprunnerlog_latest{suffix}.txt")
 
-    if suffix in LASTLOGFILEARCHIVED and LASTLOGFILEARCHIVED[suffix] and logfile_archive != LASTLOGFILEARCHIVED[suffix]:
-        import shutil
+    # archive the latest log when its last write was on an earlier UTC day. The check is
+    # mtime-based so that the short-lived worker processes also rotate their slot logs
+    openmode = "a"
+    if logfile_latest.exists():
+        lastwrite = datetime.datetime.fromtimestamp(logfile_latest.stat().st_mtime, tz=datetime.UTC)
+        if lastwrite.date() < dtnow.date():
+            import shutil
 
-        # os.rename(logfile_latest, logfile_archive)
-        shutil.copyfile(logfile_latest, logfile_archive)
-        flogfile = logfile_latest.open("w")
-    else:
-        flogfile = logfile_latest.open("a")
+            logfile_archive = Path(
+                LOG_DIR, f"fprunnerlog_{lastwrite.year:4d}-{lastwrite.month:02d}-{lastwrite.day:02d}{suffix}.txt"
+            )
+            shutil.copyfile(logfile_latest, logfile_archive)
+            openmode = "w"
 
-    LASTLOGFILEARCHIVED[suffix] = logfile_archive
-
-    # with logfile_latest.open("a") as flogfile:
-    flogfile.write(line + "\n")
-    flogfile.close()
+    with logfile_latest.open(openmode) as flogfile:
+        flogfile.write(line + "\n")
 
 
 def task_exists(taskid: int) -> bool:
@@ -102,7 +99,8 @@ def remove_task_resultfiles(
     elif request_type == "IMGZIP" and parent_task_id is not None:
         taskfiles = [Path(settings.RESULTS_DIR, localresultfileprefix(parent_task_id) + ".zip")]
     else:  # SSOSTACK
-        taskfiles = list(Path(settings.RESULTS_DIR).glob(pattern=localresultfileprefix(taskid) + ".*"))
+        # glob patterns must be relative to the globbed directory
+        taskfiles = list(Path(settings.RESULTS_DIR).glob(pattern=f"job{taskid:05d}.*"))
 
     for taskfile in taskfiles:
         if Path(taskfile).exists():
@@ -258,6 +256,8 @@ def runtask(task, logfunc, **kwargs) -> tuple[Path | None, str | None]:
         if timed_out:
             logfunc(f"ERROR: ssh was killed after exceeding TASKMAXTIME limit of {TASK_MAXTIME_SECONDS:.0f} seconds")
         os.kill(proc.pid, SIGTERM)
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)  # reap the process to avoid leaving a zombie
         return None, None  # don't finish with an error message, because we'll retry it later
 
     stdout, stderr = proc.communicate()
@@ -411,8 +411,8 @@ def send_email_if_needed(task, logfunc) -> None:
                 f"\n{taskurl}\n"
             )
 
-            if task.comment:
-                strtask += " comment: '" + task.comment + "'"
+            if batchtask.comment:
+                strtask += " comment: '" + batchtask.comment + "'"
 
             taskdesclist.append(strtask)
             localresultfilelist.append(localresultfile)
@@ -545,6 +545,9 @@ def remove_old_tasks(
         filteropts["request_type"] = request_type
 
     if not harddeleterecord:
+        if is_archived:
+            msg = "is_archived=True requires harddeleterecord=True (archiving already-archived tasks is a no-op)"
+            raise ValueError(msg)
         # exclude tasks that are already soft deleted from soft deletion query
         is_archived = False
 
@@ -601,8 +604,8 @@ def do_maintenance(maxtime=None):
 
     remove_old_tasks(days_ago=183, harddeleterecord=False, request_type="FP", logfunc=logfunc)
 
-    # archived API tasks
-    remove_old_tasks(days_ago=7, harddeleterecord=False, is_archived=True, from_api=True, logfunc=logfunc)
+    # archived (user-deleted) API tasks: remove the database records and files
+    remove_old_tasks(days_ago=7, harddeleterecord=True, is_archived=True, from_api=True, logfunc=logfunc)
 
     # other API tasks
     remove_old_tasks(days_ago=31, harddeleterecord=True, from_api=True, logfunc=logfunc)


### PR DESCRIPTION
## What changed

Bug fixes from a full review of the application code (task runner, Django app, CLI tools, and remote image scripts).

### Task runner (`atlasserver/taskrunner/main.py`)
- **SSOSTACK cleanup crash**: `remove_task_resultfiles` called `Path.glob()` with an absolute pattern, which raises `NotImplementedError` on Python 3.13+ (verified on 3.14). Deleting a cancelled SSOSTACK task killed the worker mid-cleanup. Now globs with a relative pattern.
- **Wrong comment in batch emails**: the loop over `batchtasks` appended `task.comment` (the finishing task) instead of `batchtask.comment`, so every task in the email showed the same comment.
- **"Archived API tasks" maintenance rule was a no-op as written**: `do_maintenance` passed `is_archived=True, harddeleterecord=False`, but `remove_old_tasks` silently overrode `is_archived` to `False`. Archived (user-deleted) API tasks are now hard-deleted after 7 days, and the contradictory parameter combination raises `ValueError` instead of being silently rewritten. *Please double-check this matches the intended retention policy.*
- Timed-out/cancelled ssh processes are now reaped (`proc.wait`) instead of left as zombies.
- Log rotation is now mtime-based, so the short-lived worker processes rotate their slot logs too — previously `fprunnerlog_latest_slotXX.txt` grew without bound because the rotation state was per-process.

### Django app
- **`calculate_queue_positions` skipped tasks**: it popped from `unassigned_taskids` while iterating, so the element after each assignment was skipped each pass, breaking the one-task-per-user-per-pass round-robin. Rewritten to rebuild the remaining list per pass.
- Removed the duplicate `SessionMiddleware` entry in `MIDDLEWARE`.
- `/queue/<pk>/requestimages/` now uses `<int:pk>` (non-numeric ids previously raised an uncaught `ValueError` → 500) and requires the parent task to be a non-archived FP task (previously an IMGZIP id could be used as a parent, producing a job with no input data file).
- `mjd_max` is now validated against the default `mjd_min` (30 days ago) when `mjd_min` is not supplied; previously such requests passed validation and ran an empty-range job.
- Stats perf: `statscoordchart` materializes the 20k-row queryset once instead of iterating it four times (four full queries); `statslongterm` replaces the per-country active-user N+1 with a single annotated query.
- Typo fixes in validation messages ("seimicolons", "must have have").

### CLI tools and remote scripts
- `atlaswebserver`: chmods the project's `.env` instead of whatever the current directory holds, sleeps in its wait loops instead of busy-spinning a core, and merges stderr into stdout in `run_command` so a child filling the stderr pipe can't deadlock the stdout read. Same pipe fix in `atlastaskrunner` (which also dropped a deadlock-prone `wait()` before `communicate()`).
- `atlas_gettaskimage.py` / `atlas_gettaskimage_ssostack.py`: the final jpg rename is guarded, printing an error instead of raising `FileNotFoundError` when monsta fails to produce the image.

### Tests
The previous test file contained one empty class whose `setup()` (misnamed, should be `setUp`) never ran and no test methods. Replaced with three real tests: a login-required smoke test for the task list, a round-robin regression test for `calculate_queue_positions` (fails against the old implementation), and a regression test for SSOSTACK result-file cleanup (fails with the old absolute-pattern glob).

## Notes for review

- The retention-policy change (7-day hard delete of archived API tasks) is the one behavioral judgment call — see above.
- Reviewed but deliberately **not** changed: `plot_atlas_fp.py` (third-party vendored code), the world-readable result endpoints/static results dir, the 401/403→login-redirect exception handler, and `requestimages` creating rows on GET.
- Verified with: `ruff check`, `ruff format --check`, `mypy` (no issues in 92 files), `manage.py check`, and `manage.py test` (3 tests pass; run locally against SQLite since MySQL is CI-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)