### PR TITLE
Add user-facing email change page and fix the navbar account dropdown

### DIFF
--- a/atlasserver/forcephot/forms.py
+++ b/atlasserver/forcephot/forms.py
@@ -4,6 +4,38 @@ from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import gettext_lazy as _
 
 
+class EmailChangeForm(forms.Form):
+    """A form for a logged-in user to change their account email address after confirming their password."""
+
+    error_messages = {
+        "password_incorrect": _("Your password was entered incorrectly. Please enter it again."),
+    }
+    password = forms.CharField(
+        label=_("Current password"),
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
+        help_text=_("For security, please enter your current password."),
+    )
+    new_email = forms.EmailField(
+        label=_("New email address"), max_length=254, help_text=_("Give a valid email address.")
+    )
+
+    def __init__(self, user, *args, **kwargs) -> None:
+        self.user = user
+        super().__init__(*args, **kwargs)
+
+    def clean_password(self):
+        password = self.cleaned_data["password"]
+        if not self.user.check_password(password):
+            raise forms.ValidationError(self.error_messages["password_incorrect"], code="password_incorrect")
+        return password
+
+    def save(self):
+        self.user.email = self.cleaned_data["new_email"]
+        self.user.save(update_fields=["email"])
+        return self.user
+
+
 class RegistrationForm(UserCreationForm):
     """A form that creates a user, with no privileges, from the given username and password."""
 

--- a/atlasserver/forcephot/templates/registration/email_change_form.html
+++ b/atlasserver/forcephot/templates/registration/email_change_form.html
@@ -1,0 +1,50 @@
+{% extends "rest_framework/base.html" %}
+{% load i18n static %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
+
+{% block content %}
+<div class="content-main" role="main" aria-label="main content">
+<div class="page-header">
+<h1>{% translate 'Email address change' %}</h1>
+</div>
+
+{% if success %}
+    <p class="alert alert-success">{% translate 'Your email address has been changed to' %} {{ request.user.email }}.</p>
+{% endif %}
+
+<form method="post">{% csrf_token %}
+<div>
+{% if form.errors %}
+    <p class="errornote">
+    {% if form.errors.items|length == 1 %}{% translate "Please correct the error below." %}{% else %}{% translate "Please correct the errors below." %}{% endif %}
+    </p>
+{% endif %}
+
+<p>{% translate 'Your current email address is' %} <b>{{ request.user.email }}</b>.</p>
+<p>{% translate 'Please enter your password, for security’s sake, and then enter your new email address.' %}</p>
+
+<fieldset class="module aligned wide">
+
+<div class="form-row">
+    {{ form.password.errors }}
+    {{ form.password.label_tag }} {{ form.password }}
+</div>
+
+<div class="form-row">
+    {{ form.new_email.errors }}
+    {{ form.new_email.label_tag }} {{ form.new_email }}
+    {% if form.new_email.help_text %}
+    <div class="help">{{ form.new_email.help_text|safe }}</div>
+    {% endif %}
+</div>
+
+</fieldset>
+
+<div class="submit-row">
+    <input type="submit" value="{% translate 'Change my email address' %}" class="default">
+</div>
+
+</div>
+</form></div>
+
+{% endblock %}

--- a/atlasserver/forcephot/templates/registration/password_change_done.html
+++ b/atlasserver/forcephot/templates/registration/password_change_done.html
@@ -1,6 +1,5 @@
 {% extends "rest_framework/base.html" %}
 {% load i18n %}
-{% block userlinks %}{% translate 'Change password' %} / <a href="{% url 'logout' %}">{% translate 'Log out' %}</a>{% endblock %}
 
 {% block content %}
 <div class="page-header">

--- a/atlasserver/forcephot/templates/registration/password_change_form.html
+++ b/atlasserver/forcephot/templates/registration/password_change_form.html
@@ -1,7 +1,6 @@
 {% extends "rest_framework/base.html" %}
 {% load i18n static %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">{% endblock %}
-{% block userlinks %}{% translate 'Change password' %} / <a href="{% url 'logout' %}">{% translate 'Log out' %}</a>{% endblock %}
 
 {% block content %}
 <div class="content-main" role="main" aria-label="main content">

--- a/atlasserver/forcephot/templates/rest_framework/base.html
+++ b/atlasserver/forcephot/templates/rest_framework/base.html
@@ -88,7 +88,8 @@
                           <b class="caret"></b>
                       </a>
                       <ul class="dropdown-menu dropdown-menu-right">
-                        <li><a>{{request.user.email}}</a></li>
+                        <li><a href="{% url 'email_change' %}">{{request.user.email}}</a></li>
+                        <li><a href="{% url 'email_change' %}">Change email</a></li>
                         <li><a href="{% url 'password_change' %}">Change password</a></li>
                         <li><a href="{% url 'logout' %}?next={{ request.get_full_path }}">Log out</a></li>
                       </ul>

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -49,7 +49,7 @@ class EmailChangeTests(TestCase):
     def test_requires_login(self) -> None:
         response = self.client.get(reverse("email_change"))
         assert response.status_code == 302
-        assert reverse("login") in response.url
+        assert reverse("login") in response["Location"]
 
     def test_change_email(self) -> None:
         self.client.force_login(self.user)

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -40,6 +40,45 @@ class TaskQueueTests(TestCase):
             assert {task.user_id for task in passtasks} == userids
 
 
+class EmailChangeTests(TestCase):
+    def setUp(self) -> None:
+        self.user = get_user_model().objects.create_user(
+            username="emailchanger", email="old@example.com", password="testpassword123"
+        )
+
+    def test_requires_login(self) -> None:
+        response = self.client.get(reverse("email_change"))
+        assert response.status_code == 302
+        assert reverse("login") in response.url
+
+    def test_change_email(self) -> None:
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("email_change"), {"password": "testpassword123", "new_email": "new@example.com"}
+        )
+        assert response.status_code == 200
+        self.user.refresh_from_db()
+        assert self.user.email == "new@example.com"
+
+    def test_wrong_password_rejected(self) -> None:
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("email_change"), {"password": "wrongpassword", "new_email": "new@example.com"}
+        )
+        assert response.status_code == 200
+        self.user.refresh_from_db()
+        assert self.user.email == "old@example.com"
+
+    def test_invalid_email_rejected(self) -> None:
+        self.client.force_login(self.user)
+        response = self.client.post(
+            reverse("email_change"), {"password": "testpassword123", "new_email": "not-an-email"}
+        )
+        assert response.status_code == 200
+        self.user.refresh_from_db()
+        assert self.user.email == "old@example.com"
+
+
 class TaskRunnerResultFileTests(TestCase):
     def test_remove_ssostack_resultfiles(self) -> None:
         from atlasserver.taskrunner import main as taskrunner_main

--- a/atlasserver/forcephot/urls.py
+++ b/atlasserver/forcephot/urls.py
@@ -41,7 +41,7 @@ admin.site.site_title = "ATLAS Forced Photometry"
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html"), name="index"),
     path("", include(router.urls)),
-    path("queue/<str:pk>/requestimages/", views.RequestImages.as_view(), name="requestimages"),
+    path("queue/<int:pk>/requestimages/", views.RequestImages.as_view(), name="requestimages"),
     re_path(r"^register/$", views.register, name="register"),
     path("emailchange/", views.change_email, name="email_change"),
     path("faq/", TemplateView.as_view(template_name="faq.html", extra_context={"name": "FAQ"}), name="faq"),

--- a/atlasserver/forcephot/urls.py
+++ b/atlasserver/forcephot/urls.py
@@ -41,8 +41,9 @@ admin.site.site_title = "ATLAS Forced Photometry"
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html"), name="index"),
     path("", include(router.urls)),
-    path("queue/<int:pk>/requestimages/", views.RequestImages.as_view(), name="requestimages"),
+    path("queue/<str:pk>/requestimages/", views.RequestImages.as_view(), name="requestimages"),
     re_path(r"^register/$", views.register, name="register"),
+    path("emailchange/", views.change_email, name="email_change"),
     path("faq/", TemplateView.as_view(template_name="faq.html", extra_context={"name": "FAQ"}), name="faq"),
     path(
         "resultdesc/",

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -14,6 +14,7 @@ from bokeh.embed import components
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth import login
+from django.contrib.auth.decorators import login_required
 from django.contrib.gis.geoip2 import GeoIP2
 from django.core.cache import caches
 from django.core.exceptions import ObjectDoesNotExist
@@ -46,6 +47,7 @@ from rest_framework.utils.urls import replace_query_param
 from rest_framework.views import APIView
 
 from atlasserver.forcephot.filters import TaskFilter
+from atlasserver.forcephot.forms import EmailChangeForm
 from atlasserver.forcephot.forms import RegistrationForm
 from atlasserver.forcephot.misc import country_code_to_name
 from atlasserver.forcephot.misc import country_region_to_name
@@ -691,6 +693,21 @@ def register(request):
         form = RegistrationForm()
 
     return render(request, "registration/register.html", {"form": form})
+
+
+@login_required
+def change_email(request):
+    success = False
+    if request.method == "POST":
+        form = EmailChangeForm(request.user, request.POST)
+        if form.is_valid():
+            form.save()
+            success = True
+            form = EmailChangeForm(request.user)
+    else:
+        form = EmailChangeForm(request.user)
+
+    return render(request, "registration/email_change_form.html", {"form": form, "success": success})
 
 
 def resultplotdatajs(request, taskid):

--- a/atlasserver/plot_atlas_fp.py
+++ b/atlasserver/plot_atlas_fp.py
@@ -256,7 +256,7 @@ class plotter():
         # ADD SECOND Y-AXIS
         ax2 = ax.twinx()
         ax2.yaxis.set_major_formatter(y_formatter)
-        ax2.set_ylabel('Flux ($\mu$Jy)', rotation=-90., labelpad=27)
+        ax2.set_ylabel(r'Flux ($\mu$Jy)', rotation=-90., labelpad=27)
         ax2.grid(False)
 
         # ADD SECOND X-AXIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ ignore-fully-untyped = true
 
 [tool.ruff.lint.per-file-ignores]
 "plot_atlas_fp.py" = ["ALL"]
+"**/tests.py" = ["S106"]
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
## What changed

### Email address change (main feature)

Logged-in users can now change their own account email address at `/emailchange/`, after confirming their current password. Previously the address shown in the navbar dropdown was display-only and could only be changed by an admin.

- `EmailChangeForm` (new, in `forcephot/forms.py`) — takes the current password, verified with `check_password`, plus the new address.
- `change_email` view in `forcephot/views.py`, `@login_required`, routed as `emailchange/` with URL name `email_change`.
- New template `registration/email_change_form.html`, styled to match the existing password-change page; shows the current address and a success banner after a change.
- The navbar dropdown gains a "Change email" entry, and the displayed email address links to the same page.
- `EmailChangeTests`: login required, successful change, wrong password rejected, invalid address rejected.

### Navbar dropdown fix

`password_change_form.html` and `password_change_done.html` each overrode the base template's `userlinks` block with plain text — a leftover from the Django admin templates they were copied from. That override replaced the dropdown markup from `rest_framework/base.html`, so the account menu was inert on those two pages. Removing both overrides makes the dropdown behave the same everywhere.

## Notes for reviewers

- **No verification email.** The new address takes effect immediately once the password is confirmed; nothing is sent to the new address to prove ownership. This matches current registration behavior, which also doesn't verify email. A confirmed-ownership flow would be a reasonable follow-up if you want it.
- `S106` (hardcoded password) is now ignored for `**/tests.py` via per-file-ignores in `pyproject.toml`, for the test fixture password.
- `plot_atlas_fp.py` has a one-line change making a matplotlib label a raw string, silencing an invalid-escape-sequence `SyntaxWarning`. That file is vendored third-party code, so drop this commit if you would rather send the fix upstream.

## Testing

Full suite passes (7 tests) and ruff, mypy, and pyrefly are clean. The dropdown fix was verified by rendering `/password_change/` and `/emailchange/` with a logged-in test client and confirming all three menu links are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)