### PR TITLE
Run a real task through the API and sc01 in CI

### DIFF
--- a/.github/scripts/api_task_smoketest.py
+++ b/.github/scripts/api_task_smoketest.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Submit a forced photometry task through the API and wait for the result to arrive from sc01.
+
+The unit tests mock out ssh, so nothing else checks that a task submitted by a user reaches ATLAS
+sc01, runs there, and comes back as something the user can download. This script is that check, and
+it goes through the running web server the way a user's script would (see static/apiexample.py): it
+asks for a token, queues one task, polls it until the task runner has finished it, and downloads
+the photometry.
+
+The web server and the task runner must both be running, and ATLAS_SMOKETEST_USER must name an
+account whose password is in ATLAS_SMOKETEST_PASSWORD.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# where atlaswebserver serves the site off macOS. It mounts the app at settings.PATHPREFIX, which
+# follows DEBUG, so both possibilities are tried rather than pinning that rule here as well.
+# ATLAS_SMOKETEST_BASEURL replaces the pair when the server is somewhere else entirely.
+DEFAULT_BASEURLS: tuple[str, ...] = ("http://127.0.0.1:8086/forcedphot", "http://127.0.0.1:8086")
+
+USERNAME: str = os.environ.get("ATLAS_SMOKETEST_USER", "citest")
+PASSWORD: str = os.environ.get("ATLAS_SMOKETEST_PASSWORD", "")
+
+# how long to wait for the result. force.sh takes a couple of minutes for the window requested
+# below, but sc01 is shared with the production server and with whatever else is running on it
+TIMEOUT_SECONDS: float = 15 * 60
+POLL_SECONDS: float = 5.0
+PROGRESS_SECONDS: float = 60.0
+
+# apachectl returns as soon as httpd has forked, which is a little before it serves anything
+SERVER_START_SECONDS: float = 60.0
+REQUEST_TIMEOUT_SECONDS: float = 30.0
+
+# how many days of survey data to request. Long enough that a run of bad weather at one site, or a
+# few nights lost to moonlight, cannot leave the result empty
+WINDOW_DAYS: float = 30.0
+
+
+def log(msg: str) -> None:
+    """Print a line and flush it.
+
+    CI reads this over a pipe, where the output would otherwise be held until the script exits, and
+    a run that has to be killed for taking too long is exactly the one whose progress matters.
+    """
+    print(msg, flush=True)
+
+
+def http(url: str, token: str | None = None, data: dict[str, object] | None = None) -> tuple[int, bytes]:
+    """Make one request to the server and return its status and body.
+
+    A request with `data` is a form encoded POST, which is what the API guide's examples send.
+    """
+    headers = {"Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Token {token}"
+
+    body = urllib.parse.urlencode(data).encode() if data is not None else None
+    request = urllib.request.Request(url, data=body, headers=headers)  # noqa: S310
+
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:  # noqa: S310
+            return response.status, response.read()
+    except urllib.error.HTTPError as ex:
+        # an error response is an answer from the API, and its body says what was wrong with the
+        # request, so hand it back to the caller instead of raising
+        return ex.code, ex.read()
+
+
+def mjd_now() -> float:
+    """Return the current MJD. The Unix epoch is MJD 40587."""
+    return time.time() / 86400.0 + 40587.0
+
+
+def antisolar_target() -> tuple[float, float]:
+    """Return an (RA, Dec) in degrees that the ATLAS telescopes are observing at this time of year.
+
+    A hardcoded position spends a couple of months a year too close to the Sun to be observed, and
+    a request there comes back empty, so this check would fail for weeks at a time for a reason
+    that has nothing to do with the code. The point opposite the Sun on the celestial equator rises
+    at sunset from every ATLAS site, whatever the date. The Sun's mean ecliptic longitude is used
+    here as its right ascension, which is a couple of degrees out and far more precision than is
+    needed to stay away from the Sun.
+    """
+    sun_ra_deg = (280.46 + 0.9856474 * (mjd_now() - 51544.5)) % 360.0
+
+    return round((sun_ra_deg + 180.0) % 360.0, 4), 0.0
+
+
+def find_server() -> str:
+    """Return the base URL that the site answers on, waiting for it to start serving.
+
+    apachectl returns as soon as httpd has forked, which is a little before the app answers, so a
+    slow start must not be read as a broken API.
+    """
+    override = os.environ.get("ATLAS_SMOKETEST_BASEURL", "").rstrip("/")
+    candidates = (override,) if override else DEFAULT_BASEURLS
+    deadline = time.monotonic() + SERVER_START_SECONDS
+    reasons: dict[str, str] = {}
+
+    while True:
+        for baseurl in candidates:
+            try:
+                status, _body = http(f"{baseurl}/robots.txt")
+            except urllib.error.URLError as ex:
+                reasons[baseurl] = str(ex)
+            else:
+                if status == 200:
+                    log(f"the server is answering at {baseurl}")
+                    return baseurl
+                reasons[baseurl] = f"HTTP {status}"
+
+        if time.monotonic() > deadline:
+            tried = ", ".join(f"{baseurl} ({reason})" for baseurl, reason in reasons.items())
+            sys.exit(f"ERROR: no answer from the web server after {SERVER_START_SECONDS:.0f}s. Tried {tried}")
+
+        time.sleep(1.0)
+
+
+def get_token(baseurl: str) -> str:
+    """Exchange the account's password for an API token, as the API guide tells users to."""
+    status, body = http(f"{baseurl}/api-token-auth/", data={"username": USERNAME, "password": PASSWORD})
+    if status != 200:
+        sys.exit(f"ERROR: /api-token-auth/ returned {status}: {body.decode(errors='replace')}")
+
+    return str(json.loads(body)["token"])
+
+
+def submit_task(baseurl: str, token: str) -> int:
+    """Queue one forced photometry task through the API and return its id."""
+    ra, dec = antisolar_target()
+    mjd_min = round(mjd_now() - WINDOW_DAYS, 5)
+
+    status, body = http(f"{baseurl}/queue/", token=token, data={"ra": ra, "dec": dec, "mjd_min": mjd_min})
+    if status != 201:
+        sys.exit(f"ERROR: POST to the queue returned {status}: {body.decode(errors='replace')}")
+
+    task = json.loads(body)
+    log(f"Queued task {task['id']}: RA {ra} Dec {dec}, {WINDOW_DAYS:.0f} days of data from MJD {mjd_min}")
+
+    return int(task["id"])
+
+
+def export_task_id(taskid: int) -> None:
+    """Publish the task id to the later steps of the GitHub Actions job, which clean up after it.
+
+    Whatever removes the files on sc01 has to know the id, and only the API can say what it is.
+    """
+    githubenv = os.environ.get("GITHUB_ENV")
+    if githubenv:
+        with Path(githubenv).open("a", encoding="utf-8") as envfile:
+            envfile.write(f"ATLAS_SMOKETEST_TASK_ID={taskid}\n")
+
+
+def wait_for_result(baseurl: str, token: str, taskid: int) -> dict:
+    """Poll the task until the runner marks it finished, or the timeout expires."""
+    taskurl = f"{baseurl}/queue/{taskid}/"
+    starttime = time.monotonic()
+    laststate = ""
+    lastprogress = starttime
+
+    while True:
+        status, body = http(taskurl, token=token)
+        if status != 200:
+            sys.exit(f"ERROR: GET {taskurl} returned {status}: {body.decode(errors='replace')}")
+
+        task = json.loads(body)
+        elapsed = time.monotonic() - starttime
+
+        if task["finishtimestamp"]:
+            state = "finished"
+        elif task["starttimestamp"]:
+            state = "running"
+        else:
+            state = f"queued (position {task['queuepos']})"
+
+        if state != laststate or (time.monotonic() - lastprogress) >= PROGRESS_SECONDS:
+            log(f"{elapsed:6.0f}s: task {taskid} is {state}")
+            laststate = state
+            lastprogress = time.monotonic()
+
+        if task["finishtimestamp"]:
+            return task
+
+        if elapsed >= TIMEOUT_SECONDS:
+            sys.exit(f"ERROR: task {taskid} was still {state} after {TIMEOUT_SECONDS:.0f} seconds")
+
+        time.sleep(POLL_SECONDS)
+
+
+def check_result(baseurl: str, task: dict) -> None:
+    """Fail unless the photometry that sc01 produced can be downloaded again through the server."""
+    if task["error_msg"]:
+        sys.exit(f"ERROR: task {task['id']} finished with an error: {task['error_msg']}")
+
+    # not the result_url from the response: the deployment sets a fixed Host header, so the API
+    # hands out fallingstar-data.com links that do not lead back to the server under test. This is
+    # the same file, served by Django rather than by Apache's static alias.
+    dataurl = f"{baseurl}/queue/{task['id']}/data.txt"
+    status, body = http(dataurl)
+    if status != 200:
+        sys.exit(f"ERROR: GET {dataurl} returned {status}")
+
+    lines = body.decode(errors="replace").splitlines()
+    datalines = [line for line in lines if line.strip() and not line.lstrip().startswith("#")]
+
+    log(f"{dataurl} holds {len(datalines)} rows of photometry. The first lines of it are:")
+    for line in lines[:3]:
+        log(f"  {line}")
+
+    if not datalines:
+        sys.exit(f"ERROR: task {task['id']} came back with no photometry in it")
+
+    # the preview image is made by a separate script on sc01 and its absence does not stop a task
+    # from being served, so report it rather than failing the check on it
+    log(f"preview image: {'made' if task['previewimage_url'] else 'MISSING'}")
+
+
+def main() -> None:
+    """Queue a task through the API, wait for sc01 to answer it, and check what came back."""
+    if not PASSWORD:
+        sys.exit("ERROR: ATLAS_SMOKETEST_PASSWORD is not set")
+
+    baseurl = find_server()
+    token = get_token(baseurl)
+
+    taskid = submit_task(baseurl, token)
+    export_task_id(taskid)
+
+    task = wait_for_result(baseurl, token, taskid)
+    check_result(baseurl, task)
+
+    log(f"Task {taskid} completed the round trip through the API and sc01")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,9 @@ jobs:
         name: Run tests
         environment: test
         runs-on: ubuntu-latest
+        # the job now waits on a task running on another machine, and atlaswebserver retries
+        # starting Apache forever if the port cannot be bound, so bound the whole thing
+        timeout-minutes: 45
         env:
             ATLASSERVER_DJANGO_MYSQL_DBNAME: atlasserver
             ATLASSERVER_DJANGO_MYSQL_USER: root
@@ -90,6 +93,8 @@ jobs:
             # no MySQL server; CI opts back in to the engine used in production
             ATLASSERVER_TEST_DB: mysql
             DJANGO_SETTINGS_MODULE: atlasserver.settings_test
+            # the account that the end-to-end steps below create and submit a task with
+            ATLAS_SMOKETEST_USER: citest
 
         # services:
         #     mysql:
@@ -137,6 +142,12 @@ jobs:
                   ./manage.py makemigrations --check --dry-run
                   # apply the committed migrations, which is the same path a deployment takes
                   ./manage.py migrate
+                  # task ids in this throwaway database would start at 1, but the results directory
+                  # on sc01 is shared with the production server and the remote file names are
+                  # derived from the task id. Start above any id the real server has reached, at a
+                  # different place for every run, so that no two runs (and no run and a real task)
+                  # can write the same remote file.
+                  mysql -e "ALTER TABLE forcephot_task AUTO_INCREMENT = $((2000000000 + GITHUB_RUN_ID % 100000000));" -u${{env.ATLASSERVER_DJANGO_MYSQL_USER}} -p${{env.ATLASSERVER_DJANGO_MYSQL_PASSWORD}} ${{env.ATLASSERVER_DJANGO_MYSQL_DBNAME}}
 
             - name: Run Django Tests
               run: |
@@ -148,9 +159,87 @@ jobs:
                   uv run -- coverage report
                   uv run -- coverage xml
 
-            - name: Start and stop server
+            - name: Configure ssh access to ATLAS sc01
+              # the key is a secret of this repository's test environment, so a fork cannot run the
+              # end-to-end steps. They are skipped there rather than failing every push with a key
+              # error; everything above this point still runs.
+              if: github.repository == 'lukeshingles/atlasserver'
+              env:
+                  SC01_ID_RSA: ${{ secrets.SC01_ID_RSA }}
               run: |
+                  mkdir -p ~/.ssh
+                  chmod 700 ~/.ssh
+                  # printf, so that a secret stored without a trailing newline still becomes a
+                  # valid key file, and tr, because a stray carriage return makes ssh reject it
+                  printf '%s\n' "$SC01_ID_RSA" | tr -d '\r' > ~/.ssh/sc01_id_rsa
+                  chmod 600 ~/.ssh/sc01_id_rsa
+                  cat >> ~/.ssh/config <<'EOF'
+                  Host atlas
+                      Hostname atlas-base-sc01.ifa.hawaii.edu
+                      User yoda
+                      IdentityFile ~/.ssh/sc01_id_rsa
+                      IdentitiesOnly yes
+                      BatchMode yes
+                      StrictHostKeyChecking yes
+                      ConnectTimeout 30
+                  EOF
+                  chmod 600 ~/.ssh/config
+                  # the published sc01 host key. It is listed under the name the config dials as
+                  # well as the short name, because ssh looks it up by the name it connected to.
+                  cat >> ~/.ssh/known_hosts <<'EOF'
+                  atlas-base-sc01.ifa.hawaii.edu,atlas-base-sc01 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL/VrtcyXOnossuU/WlELPu/ND+IVFDryDVYlLb0KZJX
+                  EOF
+                  chmod 600 ~/.ssh/known_hosts
+
+            - name: Check the ssh connection
+              if: github.repository == 'lukeshingles/atlasserver'
+              run: |
+                  # fails with something readable if the secret is not a usable private key,
+                  # instead of a permission denied from the far end
+                  ssh-keygen -y -f ~/.ssh/sc01_id_rsa > /dev/null
+                  ssh atlas 'hostname; mkdir -p ~/atlasserver/results'
+
+            - name: Create the account that submits the task
+              if: github.repository == 'lukeshingles/atlasserver'
+              run: |
+                  password=$(openssl rand -hex 16)
+                  echo "ATLAS_SMOKETEST_PASSWORD=$password" >> "$GITHUB_ENV"
+                  ATLAS_SMOKETEST_PASSWORD="$password" ./manage.py shell -c '
+                  import os
+
+                  from django.contrib.auth.models import User
+
+                  User.objects.create_user(
+                      os.environ["ATLAS_SMOKETEST_USER"], "citest@example.com", os.environ["ATLAS_SMOKETEST_PASSWORD"]
+                  )'
+
+            - name: Start the server and the task runner
+              run: |
+                  # the supervisor script starts appending to the log before the runner it starts
+                  # creates the directory, so make it here: a failing tee there closes the pipe
+                  # that carries the runner's stderr, which is where a crash would be reported
+                  mkdir -p atlasserver/taskrunner/logs
                   atlaswebserver start
                   atlastaskrunner start
+
+            - name: Submit a task through the API and wait for sc01 to answer it
+              if: github.repository == 'lukeshingles/atlasserver'
+              run: ./.github/scripts/api_task_smoketest.py
+
+            - name: Stop the task runner and the server
+              if: always()
+              run: |
                   atlastaskrunner stop
                   atlaswebserver stop
+
+            - name: Show the task runner log
+              # the slot log holds the remote command and everything sc01 said about it, which is
+              # the only place a failure of the step above is explained
+              if: always()
+              run: tail -n 200 atlasserver/taskrunner/logs/*.txt || echo "the task runner wrote no logs"
+
+            - name: Remove anything this run left on sc01
+              # rsync deletes the remote files as it retrieves them, so there is normally nothing
+              # here to do. The id belongs to this run alone, so no other task can be caught by it.
+              if: always() && env.ATLAS_SMOKETEST_TASK_ID != ''
+              run: ssh atlas "rm -f ~/atlasserver/results/job${ATLAS_SMOKETEST_TASK_ID}.*"


### PR DESCRIPTION
## What this does

The unit tests mock out ssh, so nothing checked that a task a user submits actually reaches ATLAS sc01, runs there, and comes back as something they can download. The `Start and stop server` step of the test job now goes the whole way:

1. **Configure ssh access to ATLAS sc01** — the key from the `SC01_ID_RSA` environment secret, the `atlas` host alias the task runner needs, and the published host key.
2. **Check the ssh connection** — `ssh-keygen -y` first, so a malformed secret fails readably instead of as a permission denied from the far end.
3. **Create the account that submits the task** — a random password and a user made through `manage.py shell`.
4. **Start the server and the task runner** — the same two commands as before.
5. **Submit a task through the API and wait for sc01 to answer it** — [`.github/scripts/api_task_smoketest.py`](.github/scripts/api_task_smoketest.py) does what `static/apiexample.py` tells users to do: asks `/api-token-auth/` for a token, POSTs one forced photometry task to `/queue/`, polls it until the task runner has finished it, and downloads the photometry.
6. **Stop, show the task runner log, remove anything left on sc01** — all `if: always()`.

The steps that need sc01 are skipped on forks, which have no access to the key. Everything else, including starting and stopping the two processes, still runs there.

## Things worth a reviewer's attention

- **Task ids are pushed above two billion**, at a different place for every run (`ALTER TABLE forcephot_task AUTO_INCREMENT` after `migrate`). `~/atlasserver/results/` on the `yoda` account is shared with the production server and the remote file names come from the task id, which would otherwise start at 1 in the throwaway CI database — so two runs, or a run and a real task, could write the same remote file. The last step deletes the run's own files if rsync did not already take them.
- **The target position is recomputed every run** as the anti-solar point on the celestial equator. A fixed RA spends a couple of months a year too close to the Sun to be observed, which would fail CI for weeks for a reason unrelated to the code.
- **The script finds the server itself** rather than the workflow naming a URL: `atlaswebserver` mounts the app at `settings.PATHPREFIX`, which follows `DEBUG` and therefore the platform, so it tries both candidates and logs which answered.
- **It downloads from `/queue/<id>/data.txt`, not the `result_url` in the response** — `httpconf.txt` pins the Host header, so the API hands out `fallingstar-data.com` links that do not lead back to the server under test.
- **The job now depends on an external machine.** If sc01 is unreachable or busier than the 15 minute wait, the test job goes red and blocks merges on unrelated changes. `continue-on-error: true` on the four sc01 steps would make it report without gating, if that is preferred.

## Testing

Run locally against a live Django server with `ssh` and `rsync` stubs standing in for sc01: token auth, `POST /queue/` (201), the task runner picking the task up and building the real `force.sh` command, the result coming back, and `GET /queue/<id>/data.txt` returning the photometry. The failure paths were checked too — task finished with an `error_msg`, result file never arrived, server not answering — each exits non-zero naming the cause. `prek`, `ruff`, `mypy` and `ty` pass.

What only a real run can show: whether sc01 accepts ssh from GitHub-hosted runner IPs, and whether the key in the secret is authorized for `yoda@atlas-base-sc01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)