### PR TITLE
Remove BrokenLinkEmailsMiddleware: stop emailing the admin about broken links

### DIFF
--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1047,6 +1047,28 @@ class AllowedHostsTests(TestCase):
 
 
 @override_settings(DEBUG=False)
+class BrokenLinkEmailTests(TestCase):
+    """A 404 must never mail the managers, whatever the referrer.
+
+    DEBUG is forced off because that is the only mode in which BrokenLinkEmailsMiddleware would
+    send anything, so with DEBUG on these would pass even if it were installed again.
+    """
+
+    def test_internal_referer_is_not_reported(self) -> None:
+        # a link to a result the retention sweep has since deleted, which is not an admin's problem
+        response = self.client.get("/queue/999999/data.txt", HTTP_REFERER="http://testserver/queue/")
+
+        assert response.status_code == 404, response.status_code
+        assert not django_mail.outbox, django_mail.outbox[0].subject
+
+    def test_external_referer_is_not_reported(self) -> None:
+        response = self.client.get("/no-such-page/", HTTP_REFERER="http://example.com/links")
+
+        assert response.status_code == 404, response.status_code
+        assert not django_mail.outbox, django_mail.outbox[0].subject
+
+
+@override_settings(DEBUG=False)
 class CallbackUrlValidationTests(TestCase):
     """The callback URL is user-supplied and the server fetches it, so this is an SSRF boundary.
 

--- a/atlasserver/settings.py
+++ b/atlasserver/settings.py
@@ -75,8 +75,11 @@ INSTALLED_APPS = [
     "geoip2",
 ]
 
+# django.middleware.common.BrokenLinkEmailsMiddleware is deliberately absent: its "Broken link on"
+# reports are dominated by links to results that the retention sweep has since deleted, and by bots
+# probing for URLs this site never had. Note that it mails MANAGERS from the middleware itself
+# rather than through LOGGING below, so leaving it installed and filtering the log is not an option.
 MIDDLEWARE = [
-    "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
## What changed

`django.middleware.common.BrokenLinkEmailsMiddleware` is removed from `MIDDLEWARE`. No 404 generates admin email any more, whatever referred it.

## Why

Neither flavour of report is actionable here:

- **"Broken INTERNAL link"** — dominated by pages holding links to results that the retention sweep (`delete_old_tasks`) has since deleted, which is working as intended.
- **"Broken link"** (external referrer) — dominated by bots probing for URLs this site never had.

Worth knowing for review: **these reports never went through `LOGGING`.** `BrokenLinkEmailsMiddleware.process_response` calls `mail_managers()` directly, so no filter or handler change — including the existing `AdminEmailHandlerNo404`, which only covers exception records — could have suppressed them. Removing the middleware is the only way. A comment in `settings.py` records that, and why the middleware is deliberately absent, so it is not innocently re-added.

Exception-level errors still mail ADMINS through the `mail_admins` handler; only the broken-link reports are gone.

## Testing

- `BrokenLinkEmailTests` asserts that a 404 mails nobody, for an internal and an external referrer. It forces `DEBUG=False` because that is the only mode in which the middleware would have sent anything — with DEBUG on the tests would pass even if it were reinstated.
- Verified both tests are meaningful: re-run against scratch settings that put the middleware back, they fail with `[Django] Broken INTERNAL link on testserver` and `[Django] Broken link on testserver` — the exact emails being received.
- Full suite green (131 tests, 1 pre-existing skip); ruff check, ruff format --check, mypy and ty all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)