### PR TITLE
Harden GeoIP/X-Forwarded-For handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ dmypy.json
 logs
 logs/*.txt
 *.mmdb
+# update_geoipdatabase.sh stages the download next to the target before renaming it into place
+*.mmdb.new
 _version.py
 .tmp
 .DS_Store

--- a/atlasserver/forcephot/models.py
+++ b/atlasserver/forcephot/models.py
@@ -285,6 +285,45 @@ class Task(models.Model):
             to_attr="live_imagerequests",
         )
 
+    def new_imagerequest(self, user) -> "Task":
+        """Return an unsaved IMGZIP task that retrieves the images behind this finished FP task.
+
+        Here rather than in the view, so that the decision of which fields a child inherits sits
+        next to the field declarations it reads. This used to be model_to_dict(exclude=["id"]) in
+        the view, which took every editable field and then corrected the ones that must not carry
+        over one at a time — so each field added to Task was inherited by default, and
+        callback_url (the parent submitter's completion webhook, fired for a task they never
+        created) was one of them. Anything not named here is left at the model default on purpose.
+        """
+        return Task(
+            user=user,
+            parent_task_id=self.id,
+            request_type=Task.RequestType.IMGZIP,
+            timestamp=datetime.datetime.now(datetime.UTC).replace(microsecond=0),
+            # the images to fetch are the observations the parent reported, so the image request
+            # describes the same target over the same window
+            mpc_name=self.mpc_name,
+            ra=self.ra,
+            dec=self.dec,
+            mjd_min=self.mjd_min,
+            mjd_max=self.mjd_max,
+            radec_epoch_year=self.radec_epoch_year,
+            propermotion_ra=self.propermotion_ra,
+            propermotion_dec=self.propermotion_dec,
+            # decides which image directory the remote script reads, so it has to match
+            use_reduced=self.use_reduced,
+            comment=self.comment,
+            # deliberately False regardless of how the parent was submitted: from_api decides
+            # which maintenance sweep collects the row (31 days for API tasks, 183 otherwise), so
+            # classifying a token-authenticated image request as API would delete it five months
+            # early
+            from_api=False,
+            send_email=False,
+            # the parent's location, kept when the caller cannot place the new request itself
+            country_code=self.country_code,
+            region=self.region,
+        )
+
     def delete_result_files(self) -> None:
         """Delete the result files belonging to this task.
 

--- a/atlasserver/forcephot/netaddr.py
+++ b/atlasserver/forcephot/netaddr.py
@@ -1,0 +1,69 @@
+"""Client IP addresses: which one a request really came from, and which ones are public.
+
+Deliberately free of imports beyond the standard library, and of Django: the callers include
+webhooks (which decides whether the server may be pointed at an address) and the GeoIP lookup in
+views (which decides whether an address is worth looking up), and webhooks is a security boundary
+that should not have to import the plotting stack to ask these questions. `misc` would be the
+obvious home, but it imports plot_atlas_fp, and so matplotlib and astropy, at module scope.
+"""
+
+import ipaddress
+
+
+def address_is_public(address: str | ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return whether an IP address is a routable public one.
+
+    One definition rather than one per caller. The users need to agree: the callback sender must
+    not be pointed at an address only the server can reach, and the GeoIP lookup must not be
+    attempted for one, since the database cannot place it. They drifted apart once before, when
+    the lookup carried a hand-written list of prefixes that missed 172.16/12 and every IPv6 form.
+
+    is_global is False for loopback, link-local (including the cloud metadata range), private,
+    reserved, multicast and unspecified addresses.
+    """
+    return ipaddress.ip_address(address).is_global
+
+
+def _unbracket(hop: str) -> str:
+    """Return an X-Forwarded-For entry with any [addr]:port wrapper removed.
+
+    nginx and several load balancers write an IPv6 address with a port in the bracketed form
+    "[2001:db8::1]:443", which ipaddress.ip_address() rejects. Only this form is unwrapped: a bare
+    "1.2.3.4:8080" cannot be told from an IPv6 address without brackets, so it is left alone and
+    simply fails to parse rather than being guessed at.
+    """
+    if hop.startswith("[") and "]" in hop:
+        return hop[1 : hop.index("]")]
+
+    return hop
+
+
+def client_address(
+    remote_addr: str | None, forwarded_for: str | None, trusted_proxy_count: int
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Return the address a request came from, or None if it cannot be established.
+
+    X-Forwarded-For is only consulted when trusted_proxy_count says a proxy in front of this
+    server maintains it, and even then only the hop that proxy itself observed is read. Anything
+    further to the left of that was written by the client. Taking the leftmost entry (as this
+    did) means the value is whatever the caller typed: it was enough to file a submission under
+    any country, and, because the string went to GeoIP2 unparsed, a name there was passed to
+    socket.gethostbyname() — an arbitrary DNS lookup performed by the server, with no timeout, on
+    a name the caller chose.
+    """
+    address = remote_addr
+
+    if trusted_proxy_count > 0 and forwarded_for:
+        hops = [stripped for hop in forwarded_for.split(",") if (stripped := hop.strip())]
+        # a chain shorter than the trusted proxies claim to have added is a forged header, not a
+        # client address: fall back to remote_addr (the nearest proxy) rather than reading a hop
+        # that the client wrote. Only the selected hop is unwrapped — the others are discarded.
+        if len(hops) >= trusted_proxy_count:
+            address = _unbracket(hops[-trusted_proxy_count])
+
+    try:
+        return ipaddress.ip_address(address) if address else None
+    except ValueError:
+        # not an address at all. Nothing here resolves names: that is what made this a request
+        # forgery surface rather than a parsing nuisance
+        return None

--- a/atlasserver/forcephot/templates/403.html
+++ b/atlasserver/forcephot/templates/403.html
@@ -1,0 +1,23 @@
+{% extends "rest_framework/base.html" %}
+
+{# Both Django's permission_denied handler and DRF's TemplateHTMLRenderer look for 403.html. #}
+{# Without it, a browser refused an action (e.g. deleting a task belonging to someone else) was #}
+{# answered by DRF's last-resort Template('403 Forbidden') — a bare line of text with no #}
+{# navigation and no way back to the queue. #}
+
+{% block title %}Not allowed – ATLAS Forced Photometry{% endblock %}
+
+{% block content %}
+<div class="content-main" role="main" aria-label="main content">
+    <div class="page-header">
+        <h1>You are not allowed to do that</h1>
+    </div>
+
+    <p>Tasks can be viewed by anyone, but only the account that submitted a task can change or
+    delete it.</p>
+
+    <p>If you expected this to work, you may be signed in as a different user.</p>
+
+    <p><a class="btn btn-info" href="{% url 'task-list' %}">Go to my task queue</a></p>
+</div>
+{% endblock %}

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1,4 +1,5 @@
 import datetime
+import ipaddress
 import itertools
 import json
 import re
@@ -33,6 +34,8 @@ from atlasserver.forcephot.models import Task
 from atlasserver.forcephot.serializers import ForcePhotTaskSerializer
 from atlasserver.forcephot.serializers import is_finite_float
 from atlasserver.forcephot.views import calculate_queue_positions
+from atlasserver.forcephot.views import geoip_reader
+from atlasserver.forcephot.views import geoip_reader_forget
 from atlasserver.forcephot.webhooks import CallbackUrlError
 from atlasserver.forcephot.webhooks import send_task_callback
 from atlasserver.forcephot.webhooks import validate_callback_url
@@ -624,6 +627,18 @@ class PermissionResponseTests(TestCase):
         self.task.refresh_from_db()
         assert self.task.comment == "not yours"
 
+    def test_a_refused_browser_action_gets_a_real_page_not_a_bare_403_string(self) -> None:
+        # without a 403.html template, DRF's TemplateHTMLRenderer falls back to
+        # Template('403 Forbidden'): one line of text, no navigation, no way back to the queue
+        self.client.force_login(self.other)
+
+        response = self.client.delete(reverse("task-detail", args=[self.task.id]), HTTP_ACCEPT="text/html")
+
+        assert response.status_code == 403, response.status_code
+        content = response.content.decode()
+        assert "<html" in content.lower(), content[:500]
+        assert reverse("task-list") in content, content[:500]
+
     def test_an_unauthenticated_browser_is_still_sent_to_the_login_page(self) -> None:
         response = self.client.get(reverse("task-list"), HTTP_ACCEPT="text/html")
 
@@ -708,6 +723,306 @@ class FromApiDetectionTests(TestCase):
         assert Task.objects.get(id=response.json()["id"]).from_api is True
 
 
+# the header line of a forced photometry result file. Module level because two unrelated test
+# classes build result files from it, and reaching across for another class's attribute made the
+# coupling invisible to a reader of either one.
+RESULTFILE_HEADER = "###MJD m dm uJy duJy F err chi/N RA Dec x y maj min phi apfit mag5sig Sky Obs"
+
+
+class ClientLocationTests(TestCase):
+    """X-Forwarded-For is written by whoever sends the request unless a proxy in front maintains it.
+
+    Nothing in this deployment does (httpconf.txt sets X-Forwarded-Proto and not this), so reading
+    the leftmost entry of it meant the client chose its own country_code — and, because the string
+    was handed to GeoIP2 unparsed, a *name* there was passed to socket.gethostbyname(): an
+    arbitrary DNS lookup made by the server, with no timeout, on a name the caller picked. A value
+    that resolved to nothing raised socket.gaierror out of task creation as a 500 and an admin
+    email.
+    """
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(username="located", email="l@example.com", password=None)
+        self.client.force_login(self.user)
+
+    @staticmethod
+    def fake_reader():
+        reader = mock.Mock()
+        reader.city.return_value = {"country_code": "ZZ", "region_code": "QQ"}
+        return reader
+
+    def submit(self, **extra):
+        return self.client.post(
+            reverse("task-list"),
+            data=json.dumps({"ra": 1.0, "dec": 2.0}),
+            content_type="application/json",
+            HTTP_ACCEPT="application/json",
+            **extra,
+        )
+
+    def created_task(self, response) -> Task:
+        assert response.status_code == 201, response.content
+        return Task.objects.get(id=response.json()["id"])
+
+    def test_x_forwarded_for_is_ignored_without_a_trusted_proxy(self) -> None:
+        # pinned rather than left to the environment: TRUSTED_PROXY_COUNT follows
+        # ATLASSERVER_TRUSTED_PROXY_COUNT, which load_dotenv applies from a developer's .env, and
+        # this is the test of the secure default
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=0),
+            mock.patch("atlasserver.forcephot.views.geoip_reader") as reader,
+        ):
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="8.8.8.8"))
+
+        # REMOTE_ADDR is 127.0.0.1 for the test client, so there is nothing to look up
+        assert reader.call_count == 0
+        assert task.country_code is None, task.country_code
+
+    def test_a_hostname_in_x_forwarded_for_is_never_resolved(self) -> None:
+        # asserted with the header trusted, which is the configuration that would reach a lookup
+        # at all: the name must be rejected by parsing, not merely by being ignored
+        with override_settings(TRUSTED_PROXY_COUNT=1), mock.patch("socket.gethostbyname") as resolve:
+            response = self.submit(HTTP_X_FORWARDED_FOR="attacker-controlled.example.com")
+
+        assert response.status_code == 201, response.content
+        assert resolve.call_count == 0, resolve.call_args_list
+
+    def test_an_unparseable_address_does_not_fail_the_submission(self) -> None:
+        # this used to escape as socket.gaierror, i.e. an HTTP 500 for a valid task request
+        with override_settings(TRUSTED_PROXY_COUNT=1), mock.patch("socket.gethostbyname") as resolve:
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="not an ip"))
+
+        assert resolve.call_count == 0, resolve.call_args_list
+        assert task.country_code is None, task.country_code
+
+    def test_a_trusted_proxy_hop_is_used_when_one_is_configured(self) -> None:
+        reader = self.fake_reader()
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=1),
+            mock.patch("atlasserver.forcephot.views.geoip_reader", return_value=reader),
+        ):
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="8.8.8.8"))
+
+        # the parsed address, not a string: GeoIP2.city() accepts one, and passing it keeps the
+        # gethostbyname fallback inside GeoIP2._query structurally unreachable
+        assert reader.city.call_args.args == (ipaddress.ip_address("8.8.8.8"),), reader.city.call_args
+        assert task.country_code == "ZZ"
+        assert task.region == "QQ"
+
+    def test_only_the_hop_the_trusted_proxy_saw_is_read(self) -> None:
+        # the client prepended its own entry; with one trusted proxy, only the last one counts
+        reader = self.fake_reader()
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=1),
+            mock.patch("atlasserver.forcephot.views.geoip_reader", return_value=reader),
+        ):
+            self.created_task(self.submit(HTTP_X_FORWARDED_FOR="1.1.1.1, 8.8.8.8"))
+
+        assert reader.city.call_args.args == (ipaddress.ip_address("8.8.8.8"),), reader.city.call_args
+
+    def test_a_bracketed_ipv6_hop_is_understood(self) -> None:
+        # nginx and several load balancers write an IPv6 address with a port this way, and
+        # ipaddress.ip_address() rejects the brackets
+        reader = self.fake_reader()
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=1),
+            mock.patch("atlasserver.forcephot.views.geoip_reader", return_value=reader),
+        ):
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="[2001:4860:4860::8888]:443"))
+
+        assert reader.city.call_args.args == (ipaddress.ip_address("2001:4860:4860::8888"),), reader.city.call_args
+        assert task.country_code == "ZZ"
+
+    def test_a_chain_shorter_than_the_proxy_count_is_not_trusted(self) -> None:
+        # two proxies are supposed to have appended, so a single entry is a forged header
+        with override_settings(TRUSTED_PROXY_COUNT=2), mock.patch("atlasserver.forcephot.views.geoip_reader") as reader:
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="8.8.8.8"))
+
+        assert reader.call_count == 0
+        assert task.country_code is None, task.country_code
+
+    def test_private_and_loopback_addresses_are_not_looked_up(self) -> None:
+        for address in ("127.0.0.1", "10.1.2.3", "192.168.0.7", "172.16.0.1", "::1", "fd00::1"):
+            with (
+                self.subTest(address=address),
+                override_settings(TRUSTED_PROXY_COUNT=1),
+                mock.patch("atlasserver.forcephot.views.geoip_reader") as reader,
+            ):
+                self.created_task(self.submit(HTTP_X_FORWARDED_FOR=address))
+                assert reader.call_count == 0, address
+
+    def test_an_address_the_database_does_not_list_is_handled_quietly(self) -> None:
+        # a routine outcome, not a fault: logging it would put a line in the log for a share of
+        # perfectly ordinary submissions
+        from geoip2.errors import AddressNotFoundError
+
+        reader = mock.Mock()
+        reader.city.side_effect = AddressNotFoundError("no such address")
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=1),
+            mock.patch("atlasserver.forcephot.views.geoip_reader", return_value=reader),
+            self.assertNoLogs("atlasserver.forcephot.views"),
+        ):
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="8.8.8.8"))
+
+        assert task.country_code is None, task.country_code
+
+    def test_an_unusable_database_is_reported_rather_than_swallowed(self) -> None:
+        from maxminddb import InvalidDatabaseError
+
+        reader = mock.Mock()
+        reader.city.side_effect = InvalidDatabaseError("corrupt")
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=1),
+            mock.patch("atlasserver.forcephot.views.geoip_reader", return_value=reader),
+            self.assertLogs("atlasserver.forcephot.views", level="ERROR"),
+        ):
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="8.8.8.8"))
+
+        assert task.country_code is None, task.country_code
+
+    def test_a_missing_database_does_not_fail_the_submission(self) -> None:
+        # geoip_reader() stats the file, so a deleted database surfaces as FileNotFoundError
+        geoip_reader_forget()
+        self.addCleanup(geoip_reader_forget)
+        with (
+            override_settings(TRUSTED_PROXY_COUNT=1, GEOIP_PATH=tempfile.gettempdir()),
+            self.assertLogs("atlasserver.forcephot.views", level="ERROR"),
+        ):
+            task = self.created_task(self.submit(HTTP_X_FORWARDED_FOR="8.8.8.8"))
+
+        assert task.country_code is None, task.country_code
+
+    def test_the_reader_is_kept_but_rebuilt_when_the_database_changes(self) -> None:
+        # constructing one opens and memory-maps the database, which was being paid again on every
+        # request that created a task — but keeping it unconditionally means the monthly
+        # update_geoipdatabase.sh replacement is never picked up by a running worker
+        geoip_reader_forget()
+        self.addCleanup(geoip_reader_forget)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dbpath = Path(tmpdir, "GeoLite2-City.mmdb")
+            dbpath.write_bytes(b"first database")
+            with (
+                override_settings(GEOIP_PATH=tmpdir),
+                mock.patch("atlasserver.forcephot.views.GeoIP2") as geoip2class,
+            ):
+                geoip_reader()
+                geoip_reader()
+                assert geoip2class.call_count == 1, geoip2class.call_count
+
+                dbpath.write_bytes(b"a replacement database of a different size")
+                geoip_reader()
+                assert geoip2class.call_count == 2, geoip2class.call_count
+
+
+class TaskDetailIsPublicTests(TestCase):
+    """A single task is readable by anyone, including anonymously, and is meant to be.
+
+    Why is explained on ForcePhotPermission.has_object_permission. Pinned by a test because the
+    task *list* is scoped to the requesting user and cross-user writes are refused, which together
+    make the public detail view look like an oversight when it is not.
+    """
+
+    def setUp(self) -> None:
+        self.owner = User.objects.create_user(username="detailowner", email="do@example.com", password=None)
+        self.other = User.objects.create_user(username="detailother", email="dt@example.com", password=None)
+        self.staff = User.objects.create_user(
+            username="detailstaff", email="ds@example.com", password=None, is_staff=True
+        )
+        self.task = Task.objects.create(user=self.owner, ra=1.0, dec=2.0, comment="shared")
+
+    def get_detail(self, accept="application/json"):
+        return self.client.get(reverse("task-detail", args=[self.task.id]), HTTP_ACCEPT=accept)
+
+    def test_the_owner_can_read_it(self) -> None:
+        self.client.force_login(self.owner)
+        response = self.get_detail()
+        assert response.status_code == 200, response.status_code
+        assert response.json()["comment"] == "shared"
+
+    def test_staff_can_read_it(self) -> None:
+        self.client.force_login(self.staff)
+        assert self.get_detail().status_code == 200
+
+    def test_another_user_can_read_it(self) -> None:
+        self.client.force_login(self.other)
+        response = self.get_detail()
+        assert response.status_code == 200, response.status_code
+        assert response.json()["comment"] == "shared"
+
+    def test_an_anonymous_caller_can_read_it(self) -> None:
+        response = self.get_detail()
+        assert response.status_code == 200, response.status_code
+        assert response.json()["comment"] == "shared"
+
+    def test_an_anonymous_browser_gets_the_task_page(self) -> None:
+        response = self.get_detail(accept="text/html")
+        assert response.status_code == 200, response.status_code
+
+    def test_the_same_caller_may_read_but_not_change(self) -> None:
+        # the boundary this class exists to describe, asserted on one caller in one test: the
+        # refusal on its own is PermissionResponseTests' subject, the contrast is this one's
+        self.client.force_login(self.other)
+
+        assert self.get_detail().status_code == 200
+
+        response = self.client.patch(
+            reverse("task-detail", args=[self.task.id]),
+            data=json.dumps({"comment": "hijacked"}),
+            content_type="application/json",
+            HTTP_ACCEPT="application/json",
+        )
+        assert response.status_code == 403, response.status_code
+
+
+class TaskResultsArePublicTests(TestCase):
+    """The result files a task produced are public, like the task detail itself.
+
+    Why is explained on ForcePhotPermission.has_object_permission; these views take a task id and
+    no credentials, and this pins that a hardening pass does not quietly lock the data.
+    """
+
+    def setUp(self) -> None:
+        self.owner = User.objects.create_user(username="fileowner", email="fo@example.com", password=None)
+        self.task = Task.objects.create(
+            user=self.owner, ra=1.0, dec=2.0, finishtimestamp=timezone.now(), request_type="IMGZIP"
+        )
+        caches["taskderived"].clear()
+
+    def urls(self) -> list[str]:
+        return [
+            reverse("taskresultdata", args=[self.task.id]),
+            reverse("taskpreviewimage", args=[self.task.id]),
+            reverse("taskimagezip", args=[self.task.id]),
+            reverse("taskpdfplot", args=[self.task.id]),
+            reverse("resultplotdatajs", args=[self.task.id]),
+        ]
+
+    def write_result_files(self, tmpdir: str) -> None:
+        prefix = Path(tmpdir, self.task.localresultfileprefix())
+        prefix.parent.mkdir(parents=True, exist_ok=True)
+        # a header with no data rows: enough for the plot view to parse and answer, without
+        # needing the plotting script it appends only when there is something to plot
+        prefix.with_suffix(".txt").write_text(RESULTFILE_HEADER + "\n")
+        for suffix in (".jpg", ".zip", ".pdf"):
+            prefix.with_suffix(suffix).write_text("results")
+
+    def test_an_anonymous_caller_can_read_every_result_view(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, override_settings(STATIC_ROOT=tmpdir):
+            self.write_result_files(tmpdir)
+            for url in self.urls():
+                with self.subTest(url=url):
+                    assert self.client.get(url).status_code == 200, url
+
+    def test_another_user_can_read_them_too(self) -> None:
+        other = User.objects.create_user(username="fileother", email="ft@example.com", password=None)
+        with tempfile.TemporaryDirectory() as tmpdir, override_settings(STATIC_ROOT=tmpdir):
+            self.write_result_files(tmpdir)
+            self.client.force_login(other)
+            for url in self.urls():
+                with self.subTest(url=url):
+                    assert self.client.get(url).status_code == 200, url
+
+
 class RequestImagesTests(TestCase):
     def setUp(self) -> None:
         self.user = User.objects.create_user(username="imgreq", email="i@example.com", password=None)
@@ -740,6 +1055,34 @@ class RequestImagesTests(TestCase):
         assert imagerequest.from_api is False
         assert imagerequest.user_id == self.user.pk
         assert imagerequest.finishtimestamp is None
+
+    def test_the_parents_completion_callback_is_not_inherited(self) -> None:
+        # model_to_dict copies every editable field of the parent, so the image request used to
+        # come out carrying the parent's callback_url: the API client that submitted the parent
+        # was then POSTed a completion notification for a task it never created and had no way to
+        # know about
+        task = Task.objects.create(
+            user=self.user,
+            ra=1.0,
+            dec=2.0,
+            finishtimestamp=timezone.now(),
+            from_api=True,
+            callback_url="https://example.com/hook",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir, override_settings(STATIC_ROOT=tmpdir):
+            resultfile = Path(tmpdir, f"{task.localresultfileprefix()}.txt")
+            resultfile.parent.mkdir(parents=True, exist_ok=True)
+            resultfile.touch()
+
+            self.client.force_login(self.user)
+            response = self.client.post(reverse("requestimages", args=[task.id]), HTTP_ACCEPT="application/json")
+
+        assert response.status_code == 302, response.status_code
+        imagerequest = Task.objects.get(parent_task_id=task.id)
+        assert imagerequest.callback_url is None, imagerequest.callback_url
+        # the parent keeps its own
+        task.refresh_from_db()
+        assert task.callback_url == "https://example.com/hook"
 
     def test_url_used_by_the_frontend_has_a_trailing_slash(self) -> None:
         # APPEND_SLASH answers a slashless POST with a 301, and a browser retries a redirected
@@ -851,10 +1194,10 @@ class TaskCreateResponseTests(TestCase):
 
 
 class ResultPlotDataTests(TestCase):
-    HEADER = "###MJD m dm uJy duJy F err chi/N RA Dec x y maj min phi apfit mag5sig Sky Obs"
-
     def setUp(self) -> None:
         self.user = User.objects.create_user(username="plotter", email="pl@example.com", password=None)
+        # deliberately not logged in: the plot data, like every other result view, is public
+
         # the taskderived cache is file-based and outlives the test database, so an entry from a
         # previous run (whose task received the same id) would poison the ragged-file assertion
         caches["taskderived"].clear()
@@ -872,7 +1215,7 @@ class ResultPlotDataTests(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir, override_settings(STATIC_ROOT=tmpdir):
             resultfile = Path(tmpdir, f"{task.localresultfileprefix()}.txt")
             resultfile.parent.mkdir(parents=True, exist_ok=True)
-            resultfile.write_text(self.HEADER + "\nWARNING: bad line\n" + self.datarow(0) + "\n")
+            resultfile.write_text(RESULTFILE_HEADER + "\nWARNING: bad line\n" + self.datarow(0) + "\n")
 
             response = self.client.get(reverse("resultplotdatajs", args=[task.id]))
             assert response.status_code == 200
@@ -883,7 +1226,7 @@ class ResultPlotDataTests(TestCase):
             Path(tmpdir, "js", "queuepage", "src").mkdir(parents=True)
             Path(tmpdir, "js", "lightcurveplotly.min.js").write_text("// plot script\n")
             Path(tmpdir, "js", "queuepage", "src", "lightcurveplotly.js").write_text("// plot script\n")
-            resultfile.write_text(self.HEADER + "\n" + self.datarow(0) + "\n" + self.datarow(1) + "\n")
+            resultfile.write_text(RESULTFILE_HEADER + "\n" + self.datarow(0) + "\n" + self.datarow(1) + "\n")
 
             response = self.client.get(reverse("resultplotdatajs", args=[task.id]))
             assert response.status_code == 200

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -1,8 +1,9 @@
 """Django views for the forcephot app."""
 
-import contextlib
 import datetime
+import ipaddress
 import json
+import logging
 import operator
 import typing as t
 from collections.abc import Callable
@@ -19,6 +20,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
 from django.contrib.gis.geoip2 import GeoIP2
+from django.contrib.gis.geoip2 import GeoIP2Exception
 from django.core.cache import caches
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
@@ -28,7 +30,6 @@ from django.db import transaction
 from django.db.models import Count
 from django.db.models import Max
 from django.db.models.functions import Trunc
-from django.forms import model_to_dict
 from django.http import FileResponse
 from django.http import HttpResponse
 from django.http import HttpResponseNotFound
@@ -41,6 +42,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
 from drf_spectacular.utils import OpenApiResponse
 from geoip2.errors import AddressNotFoundError
+from geoip2.errors import GeoIP2Error
+from maxminddb import InvalidDatabaseError
 from rest_framework import filters
 from rest_framework import permissions
 from rest_framework import serializers
@@ -62,6 +65,8 @@ from atlasserver.forcephot.misc import make_pdf_plot
 from atlasserver.forcephot.misc import resultplotdatajs_cachekey
 from atlasserver.forcephot.misc import splitradeclist
 from atlasserver.forcephot.models import Task
+from atlasserver.forcephot.netaddr import address_is_public
+from atlasserver.forcephot.netaddr import client_address
 from atlasserver.forcephot.pagination import TaskPagination
 from atlasserver.forcephot.serializers import ForcePhotTaskSerializer
 
@@ -71,6 +76,8 @@ from atlasserver.taskrunner import status as runnerstatus
 
 MAX_USER_IMGZIP_TASKS = 5
 MAX_USER_TASKS = 500
+
+logger = logging.getLogger(__name__)
 
 
 def calculate_queue_positions() -> None:
@@ -205,28 +212,107 @@ def get_tasklist_etag(request, user_id: int) -> str:
 # that forgot to supply them produced a page that polled fetch('') against itself
 
 
+def cached_by_file_stat[T](cache: dict[Path, tuple[float, int, T]], path: Path, build: Callable[[Path], T]) -> T:
+    """Return build(path), reusing the last result until the file's mtime or size changes.
+
+    Turns a repeated read (or a repeated open, for the GeoIP database) into a stat, without the
+    staleness that keeping the value forever would bring: both callers here read a file that is
+    replaced underneath a long-lived worker process, one by a deployment and one by cron.
+
+    No lock. Two threads racing build the value twice and one wins the dict, which costs the extra
+    work rather than a wrong answer.
+    """
+    stat = path.stat()
+
+    cached = cache.get(path)
+    if cached is not None and cached[0] == stat.st_mtime and cached[1] == stat.st_size:
+        return cached[2]
+
+    value = build(path)
+    cache[path] = (stat.st_mtime, stat.st_size, value)
+    return value
+
+
+_geoip_reader_cache: dict[Path, tuple[float, int, GeoIP2]] = {}
+
+
+def geoip_reader() -> GeoIP2:
+    """Return a reader for the city database, rebuilding it only when the file changes.
+
+    Constructing one opens and memory-maps the database, which was being paid again on every
+    request that created a task. Not held forever, because update_geoipdatabase.sh replaces the
+    database from cron and a reader kept across the replacement answers from the mapping it opened
+    for the rest of the worker process's life.
+
+    The path is resolved here rather than left to GeoIP2's own directory search, because there is
+    nothing to stat until it has been. GEOIP_CITY is Django's own setting for the file name.
+    """
+    path = Path(settings.GEOIP_PATH, getattr(settings, "GEOIP_CITY", "GeoLite2-City.mmdb"))
+
+    return cached_by_file_stat(_geoip_reader_cache, path, lambda dbpath: GeoIP2(path=dbpath))
+
+
+def geoip_reader_forget() -> None:
+    """Drop any held reader, so the next lookup reopens the database.
+
+    The seam tests reset the module state through, rather than reaching into the private dict.
+    """
+    _geoip_reader_cache.clear()
+
+
+def client_ip(request) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Return the address the request came from, or None if it cannot be established.
+
+    The policy (and the reasoning behind it) lives in netaddr.client_address; this only supplies
+    the request pieces. NUM_PROXIES in REST_FRAMEWORK is set from the same TRUSTED_PROXY_COUNT so
+    that the throttle's idea of the client cannot drift from this one.
+    """
+    return client_address(
+        remote_addr=request.META.get("REMOTE_ADDR"),
+        forwarded_for=request.META.get("HTTP_X_FORWARDED_FOR"),
+        trusted_proxy_count=settings.TRUSTED_PROXY_COUNT,
+    )
+
+
 def client_location_fields(request) -> dict[str, str | None]:
     """Return the country_code/region fields for the request's client IP, when it can be located.
 
     One implementation rather than one per task-creating view: the private-range list and the
     header handling drifted apart once before, and a divergence here quietly feeds wrong countries
     into the usage statistics.
-    """
-    if x_forwarded_for := request.META.get("HTTP_X_FORWARDED_FOR"):
-        ip = x_forwarded_for.split(",")[0]
-    else:
-        ip = request.META.get("REMOTE_ADDR")
 
+    Never raises. This decorates a task with a statistic, so no failure of it is worth failing a
+    submission for — an unresolvable lookup used to escape as a 500 (and an admin email) from the
+    middle of task creation.
+    """
     # str | None values: the GeoIP database does not know a region for every address, and the
     # model fields are nullable, so a None is stored as-is rather than dropped
     fields: dict[str, str | None] = {}
-    # private-range addresses (local submissions) have no meaningful GeoIP location
-    if ip is not None and not ip.startswith(("192.168.", "127.0.", "10.")):
-        geoip = GeoIP2()
-        with contextlib.suppress(AddressNotFoundError):
-            location = geoip.city(ip)
-            fields["country_code"] = location["country_code"]
-            fields["region"] = location["region_code"]
+
+    ip = client_ip(request)
+    # the shared definition, not a second copy of it: the database cannot place any address that
+    # webhooks refuses to send to, and the two used to disagree because this end carried a
+    # hand-written prefix list that missed 172.16/12 and every IPv6 form
+    if ip is None or not address_is_public(ip):
+        return fields
+
+    try:
+        location = geoip_reader().city(ip)
+    except AddressNotFoundError:
+        # a public address the database simply does not list (an unallocated or anonymised range,
+        # or most IPv6). Routine, and silent for that reason: logging it would put a line in the
+        # log for a share of perfectly ordinary submissions and bury the failures below in them
+        return fields
+    except (GeoIP2Exception, GeoIP2Error, InvalidDatabaseError, OSError):
+        # the database is missing, unreadable or corrupt (OSError covers the stat in geoip_reader,
+        # which is where a deleted file surfaces). Unlike the case above this is a real fault, so
+        # it is reported at error level, where the "atlasserver" logger writes it to the log file.
+        # Deliberately not mail_admins: a database that has gone bad would mail on every request.
+        logger.exception("GeoIP lookup failed for %s", ip)
+        return fields
+
+    fields["country_code"] = location["country_code"]
+    fields["region"] = location["region_code"]
 
     return fields
 
@@ -247,23 +333,22 @@ def request_is_from_api(request) -> bool:
 
 
 class ForcePhotPermission(permissions.BasePermission):
-    """Custom permission to only allow owners of an object to edit it."""
+    """Object-level permission to only allow owners of an object to change it.
+
+    Assumes the model instance has a `user` attribute.
+    """
 
     message = "You must be the owner of this object."
 
     def has_permission(self, request, view) -> bool:
         return bool(request.method in permissions.SAFE_METHODS or request.user.is_authenticated)
 
-    #     return request.user and request.user.is_authenticated
-
-    """
-    Object-level permission to only allow owners of an object to edit it.
-    Assumes the model instance has an `user` attribute.
-    """
-
     def has_object_permission(self, request, view, obj) -> bool:
-        # Read permissions are allowed to any request,
-        # so we'll always allow GET, HEAD or OPTIONS requests.
+        # Reading a task is public, including to anonymous callers, and is meant to be: a task and
+        # the results it produced describe measurements from a public survey, so a link to one can
+        # be shared with somebody who has no account here. Only changing it is restricted.
+        # (The task *list* is a different question and stays scoped to the requesting user: it is
+        # a person's own queue, not a public index.)
         if request.method in permissions.SAFE_METHODS:
             return True
 
@@ -271,7 +356,7 @@ class ForcePhotPermission(permissions.BasePermission):
             return False
 
         # staff and instance owner have all permissions
-        return True if request.user.is_staff else obj.user.id == request.user.id
+        return request.user.is_staff or obj.user_id == request.user.id
 
 
 class ForcePhotTaskViewSet(viewsets.ModelViewSet):
@@ -500,23 +585,10 @@ class RequestImages(APIView):
                 return JsonResponse({"non_field_errors": msg}, status=429)
 
         if not parent_task.error_msg and parent_task.finishtimestamp:
-            data = model_to_dict(parent_task, exclude=["id"])
-            data["parent_task_id"] = parent_task.id
-            data["request_type"] = Task.RequestType.IMGZIP
-            data["user"] = request.user
-            data["timestamp"] = datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat()
-            data["starttimestamp"] = None
-            data["finishtimestamp"] = None
-
-            data.update(client_location_fields(self.request))
-
-            # deliberately not request_is_from_api(): from_api decides which maintenance sweep
-            # collects the row (31 days for API tasks, 183 otherwise), so classifying a
-            # token-authenticated image request as API would delete it five months early
-            data["from_api"] = False
-            data["send_email"] = False
-
-            newtask = Task(**data)
+            # which fields the child inherits is the model's decision; see Task.new_imagerequest
+            newtask = parent_task.new_imagerequest(user=request.user)
+            for field, value in client_location_fields(self.request).items():
+                setattr(newtask, field, value)
             newtask.save()
             calculate_queue_positions()
 
@@ -901,18 +973,11 @@ def read_plotscript(path: Path) -> str:
     Keying on the file's mtime and size preserves that while turning a disk read per request into a
     stat per request.
     """
-    stat = path.stat()
-    cached = _plotscript_cache.get(path)
-    if cached is not None and cached[0] == stat.st_mtime and cached[1] == stat.st_size:
-        return cached[2]
-
     # explicit encoding, because read_text() would otherwise decode with the locale encoding, and
     # under mod_wsgi that is often the C locale's ASCII. The script carries non-ASCII characters
     # (the "Flux / µJy" axis label) now that babel emits them literally instead of as \xNN escapes,
     # so a locale-dependent read is the difference between a working plot and a 500 on every one.
-    contents = path.read_text(encoding="utf-8")
-    _plotscript_cache[path] = (stat.st_mtime, stat.st_size, contents)
-    return contents
+    return cached_by_file_stat(_plotscript_cache, path, lambda scriptpath: scriptpath.read_text(encoding="utf-8"))
 
 
 def resultplotdatajs(request, taskid):
@@ -1075,6 +1140,11 @@ def taskpdfplot(request, taskid):
     return HttpResponseNotFound("ERROR: Could not generate PDF plot (perhaps a lack of data points?)")
 
 
+# Results are public on purpose, like the task detail itself — the reasoning lives on
+# ForcePhotPermission.has_object_permission. The file views below (and taskpdfplot and
+# resultplotdatajs above) therefore take a task id and no credentials; note the serializer also
+# links results at their STATIC_URL path, which Apache serves without consulting Django at all.
+#
 # no @cache_page on the result file views: Django's cache middleware skips streaming responses, so
 # decorating a view that returns a FileResponse only adds a lookup that can never hit
 def _taskresultfile_response(

--- a/atlasserver/forcephot/webhooks.py
+++ b/atlasserver/forcephot/webhooks.py
@@ -10,7 +10,6 @@ oracle. validate_callback_url() is applied when the task is submitted and again 
 the request is sent.
 """
 
-import ipaddress
 import json
 import socket
 import typing as t
@@ -19,6 +18,8 @@ import urllib.request
 from urllib.parse import urlparse
 
 from django.conf import settings
+
+from atlasserver.forcephot.netaddr import address_is_public
 
 # a callback is a courtesy, not part of finishing the task: keep it short so that a slow or
 # blackholed endpoint cannot hold a worker slot open
@@ -29,14 +30,6 @@ MAX_CALLBACK_URL_LENGTH = 500
 
 class CallbackUrlError(ValueError):
     """Raised when a callback URL is missing, malformed or points somewhere it must not."""
-
-
-def _address_is_forbidden(address: str) -> bool:
-    """Return whether an IP address is one the server must not be pointed at."""
-    ip = ipaddress.ip_address(address)
-    # is_global is False for loopback, link-local (including the cloud metadata range),
-    # private, reserved, multicast and unspecified addresses
-    return not ip.is_global
 
 
 def validate_callback_url(url: str) -> str:
@@ -87,7 +80,9 @@ def validate_callback_url(url: str) -> str:
         # sockaddr is (host, port) for IPv4 and (host, port, flowinfo, scopeid) for IPv6; the
         # stubs type the first element as str | int because of AF_UNIX
         host = sockaddr[0]
-        if isinstance(host, str) and _address_is_forbidden(host):
+        # the same definition of "public" as the GeoIP lookup in views.client_location_fields,
+        # which must skip exactly the addresses this refuses; see the note on drift in netaddr
+        if isinstance(host, str) and not address_is_public(host):
             msg = "callback_url must resolve to a public address"
             raise CallbackUrlError(msg)
 

--- a/atlasserver/settings.py
+++ b/atlasserver/settings.py
@@ -29,6 +29,23 @@ if not SECRET_KEY:
 
 TEST_USERS = [int(x) for x in os.environ.get("ATLASSERVER_TEST_USERS", "").split(",") if x]
 
+# How many reverse proxies in front of this server append to X-Forwarded-For. Zero means the
+# header is ignored entirely, which is right for the current deployment: httpconf.txt sets
+# X-Forwarded-Proto but nothing sets X-Forwarded-For, so every value of it is client-supplied and
+# says only what the client chose to claim. Set this only if a proxy that *overwrites* the header
+# (or appends to a chain it controls) is actually in front, and count the proxies exactly: reading
+# one hop too far left takes the attacker's value again.
+#
+# Validated rather than passed straight to int(), for the same reason as ATLASSERVER_DEBUG below:
+# a typo here is a bare ValueError at import that names no variable, and the site does not start.
+_proxycount_env = os.environ.get("ATLASSERVER_TRUSTED_PROXY_COUNT", "0").strip() or "0"
+# isdecimal, not isdigit: isdigit also accepts superscripts, and "²" would pass the check and
+# then fail int() with the bare ValueError this exists to replace
+if not _proxycount_env.isdecimal():
+    _msg = f"ATLASSERVER_TRUSTED_PROXY_COUNT must be a non-negative integer, not {_proxycount_env!r}"
+    raise ImproperlyConfigured(_msg)
+TRUSTED_PROXY_COUNT = int(_proxycount_env)
+
 # See https://docs.djangoproject.com/en/6.1/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -284,6 +301,11 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "forcephottasks": "60/min",
     },
+    # the same knob as TRUSTED_PROXY_COUNT above, so the throttle's idea of the client address
+    # cannot drift from the GeoIP lookup's. Left unset, DRF's get_ident() trusts the whole
+    # client-written X-Forwarded-For header for anonymous callers — the exact forgery
+    # netaddr.client_address exists to stop. With 0, it uses REMOTE_ADDR.
+    "NUM_PROXIES": TRUSTED_PROXY_COUNT,
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     # JSON first: DRF picks the first renderer for an "Accept: */*" request (what a script sends
     # when it sets no Accept header), and TemplateHTMLRenderer answers those with an HTML page,
@@ -385,6 +407,15 @@ LOGGING = {
     "loggers": {
         "django": {
             "handlers": ["console", "mail_admins", "file"],
+            "level": "INFO",
+        },
+        # this project's own modules. Without an entry here they inherit a root logger that has no
+        # handler either, so logging.lastResort writes them unformatted to stderr — which under
+        # mod_wsgi means Apache's error log rather than the file below, and nothing at all under
+        # runserver. No mail_admins: what these report is degraded service (e.g. an unusable GeoIP
+        # database), which would otherwise mail on every affected request.
+        "atlasserver": {
+            "handlers": ["console", "file"],
             "level": "INFO",
         },
         # every bot probing with a forged Host header raises DisallowedHost, which would otherwise

--- a/dotenv_example.txt
+++ b/dotenv_example.txt
@@ -14,6 +14,9 @@ export ATLASSERVER_DJANGO_MYSQL_PASSWORD='PASSWORD'
 
 export MAXMIND_LICENSE_KEY=''
 
+export ATLASSERVER_NPROCESSES='4'
+export ATLASSERVER_NTHREADPERPROC='1'
+
 # Number of reverse proxies in front of this server that maintain X-Forwarded-For. Leave at 0
 # unless one really is in front: with 0 the header is ignored and the client address is taken from
 # the connection, which is what stops a caller choosing the country their submissions are filed

--- a/dotenv_example.txt
+++ b/dotenv_example.txt
@@ -13,3 +13,9 @@ export ATLASSERVER_DJANGO_MYSQL_USER='djangouser'
 export ATLASSERVER_DJANGO_MYSQL_PASSWORD='PASSWORD'
 
 export MAXMIND_LICENSE_KEY=''
+
+# Number of reverse proxies in front of this server that maintain X-Forwarded-For. Leave at 0
+# unless one really is in front: with 0 the header is ignored and the client address is taken from
+# the connection, which is what stops a caller choosing the country their submissions are filed
+# under. Count the proxies exactly — one hop too many reads a value the client wrote.
+export ATLASSERVER_TRUSTED_PROXY_COUNT='0'

--- a/update_geoipdatabase.sh
+++ b/update_geoipdatabase.sh
@@ -19,7 +19,23 @@ for edition in GeoLite2-ASN GeoLite2-City; do
         "https://download.maxmind.com/geoip/databases/$edition/download?suffix=tar.gz" \
         --output "$tempdir/$edition.tar.gz"; then
         tar -zxvf "$tempdir/$edition.tar.gz" -C "$tempdir"
-        cp "$tempdir"/GeoLite2-*/"$edition.mmdb" "$ATLASSERVERPATH/atlasserver/$edition.mmdb"
+        # copy alongside the target and rename, rather than cp'ing over it: the web server holds
+        # the database memory-mapped, and cp truncates and rewrites the same inode, so a plain cp
+        # rewrites the bytes underneath the running process. A rename leaves the old inode intact
+        # for anyone still reading it and publishes the new file in one step. The temporary copy
+        # goes in the destination directory because rename cannot cross filesystems.
+        # &&, because there is no `set -e`: a cp that ran out of disk part-way leaves a truncated
+        # .new file, and an unconditional mv would publish that over the working database as
+        # atomically as it publishes a good one
+        staged="$ATLASSERVERPATH/atlasserver/$edition.mmdb.new"
+        if cp "$tempdir"/GeoLite2-*/"$edition.mmdb" "$staged" &&
+            mv -f "$staged" "$ATLASSERVERPATH/atlasserver/$edition.mmdb"; then
+            echo "Installed $edition.mmdb"
+        else
+            echo "ERROR: failed to install $edition.mmdb"
+            rm -f "$staged"
+            exitcode=1
+        fi
     else
         echo "ERROR: failed to download $edition (is MAXMIND_LICENSE_KEY set in .env?)"
         exitcode=1


### PR DESCRIPTION
## What changed

Stops trusting the client-supplied `X-Forwarded-For` header for GeoIP and rate limiting, and fixes several related issues found while reviewing the change.

- **`X-Forwarded-For` is now ignored unless a trusted proxy maintains it.** The header was read unconditionally (leftmost entry), so any caller could choose the country their submissions were filed under — and because the raw string went to GeoIP2 unparsed, a hostname there was passed to `socket.gethostbyname()`: an arbitrary server-side DNS lookup with no timeout, and unresolvable values escaped task creation as a 500 plus an admin email. A new stdlib-only `netaddr` module parses addresses with `ipaddress` (names are never resolved, bracketed IPv6 hops are understood) and reads only the hop the trusted proxy observed, governed by a new `ATLASSERVER_TRUSTED_PROXY_COUNT` env var (default 0, correct for the current Apache setup — nothing sets the header).
- **`REST_FRAMEWORK["NUM_PROXIES"]` is set from the same knob**, so DRF's throttle identity for anonymous callers can't drift from the GeoIP policy (previously unset, meaning the throttle trusted the whole client-written header).
- **The GeoIP reader is cached behind an mtime/size stat** instead of being reopened (open + mmap) on every task-creating request, via a `cached_by_file_stat` helper shared with `read_plotscript`. `update_geoipdatabase.sh` now stages the download and renames it into place — a plain `cp` truncated and rewrote the same inode under the running workers' live mapping — and refuses to publish a failed copy.
- **GeoIP failures no longer 500 a submission**: address-not-found is silent (routine), a missing/corrupt database is logged through a new `atlasserver` logger wired into `LOGGING` (previously project loggers fell through to `logging.lastResort` on stderr).
- **`address_is_public()` is shared** between the webhook SSRF guard and the GeoIP lookup, so the two definitions of "public address" cannot drift again (the lookup previously carried a prefix list that missed 172.16/12 and all IPv6).
- **Image requests inherit an explicit field list** via `Task.new_imagerequest()` instead of `model_to_dict()`, so new `Task` fields are not carried over by accident — `callback_url` was, firing the parent API client's completion webhook for a task it never created.
- **`403.html` template added** so a refused browser action (e.g. cross-user delete) renders a real page instead of DRF's bare `403 Forbidden` fallback string.
- **`ATLASSERVER_TRUSTED_PROXY_COUNT` is validated at import** with a named `ImproperlyConfigured`, matching the existing `ATLASSERVER_DEBUG` handling, rather than dying on a bare `ValueError` that names no variable.

## Notes for review

- **No read access was tightened.** An earlier pass restricted the task detail endpoint and the result-file views to owners; both were reverted — task details and results are public by design. That intent is now pinned by `TaskDetailIsPublicTests` and `TaskResultsArePublicTests` and explained on `ForcePhotPermission.has_object_permission`, so a future hardening pass fails a test instead of quietly locking the data.
- **No deployment change needed.** `TRUSTED_PROXY_COUNT` defaults to `0`, which ignores the header entirely and is correct for the current Apache setup. Only set it if a proxy that maintains `X-Forwarded-For` is genuinely in front, and count the hops exactly — one too many reads a value the client wrote.
- **`NUM_PROXIES = 0` is a behaviour change for throttling**: anonymous throttle identity moves from "whatever the caller claimed in the header" to `REMOTE_ADDR`. That is the intended fix, but it changes bucketing for any client that was getting a per-header bucket.
- 153 tests pass; `ruff`, `ruff format`, `mypy` and `makemigrations --check` are clean. Verified locally against SQLite (the suite's default); CI runs it against MySQL 8.4.
- Deliberately **not** addressed here: `taskpdfplot` is unauthenticated and forks a matplotlib process per uncached task id, so it remains a load surface. That's a rate-limiting question, not an access one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)