### PR TITLE
Stop the navbar shrink jerking, and let the mark follow the scroll

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -22,6 +22,9 @@ a {
    link and link-hover; the active item is the same blue as the rest, distinguished by the
    underline below, as it was before. */
 .navbar {
+  /* in step with the height the brand gives up, so the space the bar occupies stays constant
+     through the travel and not only at its two ends; see .navbar-stuck below */
+  transition: margin-bottom 200ms ease;
   --bs-navbar-color: var(--bs-link-color);
   --bs-navbar-hover-color: var(--bs-link-hover-color);
   --bs-navbar-active-color: var(--bs-link-color);
@@ -49,6 +52,37 @@ a {
 .navbar.navbar-stuck {
   border-bottom: var(--bs-border-width) solid var(--bs-border-color);
   box-shadow: var(--bs-box-shadow-sm, 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075));
+  /*
+  The height the mark gives up is handed straight back as margin, so the space the bar occupies in
+  the page does not change. This is what stops the shrink from arriving in jerks, and the reason is
+  a loop rather than anything about how the mark is drawn:
+
+  the bar is sticky, so its box is still page space. Shrinking it took 74px out of the document,
+  the browser's scroll anchoring pulled the scroll position back by about as much to hold the
+  content still, and that carried the sentinel above the bar back into view -- which is the one
+  thing that says the bar is not stuck. The class came off, the mark grew again, the document grew
+  with it, and the whole thing went round again. Measured on a slow scroll: nine stuck/unstuck
+  toggles, the mark growing again on thirteen frames, and the page moving under the reader
+  forty-eight times.
+
+  A fast scroll clears the sentinel in one movement and never gives the loop a second pass, which
+  is why this looked like a drawing fault rather than a loop, and why it only showed when scrolling
+  slowly.
+
+  With the space held constant there is nothing for scroll anchoring to correct and the loop cannot
+  start: the same slow scroll makes one toggle, and the page does not move at all. The alternative
+  -- overflow-anchor: none on the page -- also breaks the loop, but it gives up scroll anchoring
+  everywhere, and it still lets the document change height, so the page went on jumping by up to
+  26px. This keeps the feature, and the queue page filling itself in above the viewport is exactly
+  what the feature is for.
+
+  The consequence to know about: the page now reserves the tall bar's height at the top whether the
+  bar is stuck or not, so content sits where it sits at rest rather than sliding up under the bar
+  as soon as the bar shrinks. That is the point -- what used to move it is what was jerking.
+
+  74px is what the mark gives up, 118 - 44. The pair below the navbar breakpoint is 56 - 38.
+  */
+  margin-bottom: 74px;
 }
 
 /*
@@ -67,69 +101,22 @@ in the query, the -webkit- form included, since that is the only form Safari has
   }
 }
 
-/*
-The brand box owns the height the bar gives up; the mark inside it is scaled rather than resized.
-
-The mark used to animate its own `height`, and that is a layout property on an inline <svg>: every
-frame of the 200ms re-laid-out the bar, re-flowed the page under it, and re-rasterised the artwork
-at a size it would never be seen at again -- all of it behind the stuck bar's backdrop-filter,
-which then had to re-blur the moving content underneath. It arrived in steps rather than shrinking.
-
-So the <svg> keeps one height and one rasterisation, and `transform: scale()` does the shrinking on
-the compositor. The height that the layout actually needs moves on this box, which is an empty
-block and cheap to re-lay-out.
-
-The two stay locked together because the numbers agree: the box travels 118px -> 44px, and the mark
-is scaled by 44/118, so its drawn height is 118 x scale at every point of the same easing --
-118 x (1 - 44/118) = 74, which is exactly the distance the box falls. Change one of the four
-numbers and the mark leaves the box mid-travel.
-*/
 .navbar-brand {
-  align-items: center;
-  /* content-box, so these are the mark's own dimensions and not the mark's dimensions less
-     Bootstrap's vertical padding on the brand. Under the inherited border-box the bar came out
-     10px shorter than it was when the <svg> sized the box itself. */
-  box-sizing: content-box;
-  display: flex;
-  height: 118px;
-  /* The width has to be given as well as the height. A transform is not a layout, so the mark
-     inside keeps its full width however far it is scaled down, and the links beside it would sit
-     where the unscaled mark left them. Both numbers are the mark's viewBox, 246 x 214, at the
-     height above: 118 x 246/214 = 135.6449. The two below are 44 x 246/214 and the small-screen
-     pair further down are the same arithmetic on 56 and 38. Re-do all four if the artwork's
-     viewBox ever changes. */
-  transition: height 200ms ease, width 200ms ease;
-  width: 135.6449px;
+  height: auto;
 }
 
 /* width follows from the viewBox's aspect ratio, so only the height is given, as it was when this
    was an <img> */
 .navbar-brand .atlaslogo {
-  /* No shrinking. The mark is a flex item in the box above, and that box is narrowed to the
-     scaled-down width: left to flex, the mark's own width would be squeezed to fit it, the
-     artwork would letterbox itself down to the smaller size, and the scale below would then
-     shrink it a second time. Its box keeps the full size and the transform is the only thing
-     that resizes it. */
-  flex-shrink: 0;
   height: 118px;
-  /* the box it keeps is wider than the brand once scaled down, and it is decoration -- the link
-     around it is what a click is for, and the mark is aria-hidden. Without this the part of the
-     box hanging past the brand would take clicks meant for the navigation beside it. */
-  pointer-events: none;
-  transform-origin: left center;
-  transition: transform 200ms ease;
+  transition: height 200ms ease;
 }
 
 /* A 118px logo at the top of the window is most of a phone screen and a good deal of a laptop one,
    so once the bar is stuck it gives up its height to the content behind it. The links stay put:
    Bootstrap centres them against the brand, so the bar closes up around them. */
-.navbar-stuck .navbar-brand {
-  height: 44px;
-  width: 50.5794px;
-}
-
 .navbar-stuck .navbar-brand .atlaslogo {
-  transform: scale(0.3728813559322034);
+  height: 44px;
 }
 
 /* The mark carries no background of its own, so on the dark theme its one shape that touches the
@@ -1509,24 +1496,18 @@ table.countrystats th[scope="row"] {
    block that used to be here worked around bootstrap 3 having no toggle at all, so the eight links
    plus a floated logo filled an entire screen before any content. */
 @media (max-width: 991.98px) {
-  .navbar-brand,
   .navbar-brand .atlaslogo {
     height: 56px;
   }
 
-  .navbar-brand {
-    width: 64.3738px;
-  }
-
-  /* after the rule above, so it is this one that applies when both match. 56 x (1 - 38/56) = 18,
-     the distance the box falls, so the mark stays inside it for the whole travel here too. */
-  .navbar-stuck .navbar-brand {
-    height: 38px;
-    width: 43.6822px;
-  }
-
+  /* after the rule above, so it is this one that applies when both match */
   .navbar-stuck .navbar-brand .atlaslogo {
-    transform: scale(0.6785714285714286);
+    height: 38px;
+  }
+
+  /* 56 - 38, the height the mark gives up at this width */
+  .navbar.navbar-stuck {
+    margin-bottom: 18px;
   }
 
   /* The collapsed menu opens inside the sticky bar, and it is a tall menu -- seven links, the
@@ -1636,7 +1617,7 @@ ul.tasks li.task.task-collapsed > .taskinner {
 @media (prefers-reduced-motion: reduce) {
 
   li.task,
-  .navbar-brand,
+  .navbar,
   .navbar-brand .atlaslogo,
   .navindicator-host.navindicator-animated .navindicator,
   li.task>.taskinner,

--- a/static/main.css
+++ b/static/main.css
@@ -67,22 +67,69 @@ in the query, the -webkit- form included, since that is the only form Safari has
   }
 }
 
+/*
+The brand box owns the height the bar gives up; the mark inside it is scaled rather than resized.
+
+The mark used to animate its own `height`, and that is a layout property on an inline <svg>: every
+frame of the 200ms re-laid-out the bar, re-flowed the page under it, and re-rasterised the artwork
+at a size it would never be seen at again -- all of it behind the stuck bar's backdrop-filter,
+which then had to re-blur the moving content underneath. It arrived in steps rather than shrinking.
+
+So the <svg> keeps one height and one rasterisation, and `transform: scale()` does the shrinking on
+the compositor. The height that the layout actually needs moves on this box, which is an empty
+block and cheap to re-lay-out.
+
+The two stay locked together because the numbers agree: the box travels 118px -> 44px, and the mark
+is scaled by 44/118, so its drawn height is 118 x scale at every point of the same easing --
+118 x (1 - 44/118) = 74, which is exactly the distance the box falls. Change one of the four
+numbers and the mark leaves the box mid-travel.
+*/
 .navbar-brand {
-  height: auto;
+  align-items: center;
+  /* content-box, so these are the mark's own dimensions and not the mark's dimensions less
+     Bootstrap's vertical padding on the brand. Under the inherited border-box the bar came out
+     10px shorter than it was when the <svg> sized the box itself. */
+  box-sizing: content-box;
+  display: flex;
+  height: 118px;
+  /* The width has to be given as well as the height. A transform is not a layout, so the mark
+     inside keeps its full width however far it is scaled down, and the links beside it would sit
+     where the unscaled mark left them. Both numbers are the mark's viewBox, 246 x 214, at the
+     height above: 118 x 246/214 = 135.6449. The two below are 44 x 246/214 and the small-screen
+     pair further down are the same arithmetic on 56 and 38. Re-do all four if the artwork's
+     viewBox ever changes. */
+  transition: height 200ms ease, width 200ms ease;
+  width: 135.6449px;
 }
 
 /* width follows from the viewBox's aspect ratio, so only the height is given, as it was when this
    was an <img> */
 .navbar-brand .atlaslogo {
+  /* No shrinking. The mark is a flex item in the box above, and that box is narrowed to the
+     scaled-down width: left to flex, the mark's own width would be squeezed to fit it, the
+     artwork would letterbox itself down to the smaller size, and the scale below would then
+     shrink it a second time. Its box keeps the full size and the transform is the only thing
+     that resizes it. */
+  flex-shrink: 0;
   height: 118px;
-  transition: height 200ms ease;
+  /* the box it keeps is wider than the brand once scaled down, and it is decoration -- the link
+     around it is what a click is for, and the mark is aria-hidden. Without this the part of the
+     box hanging past the brand would take clicks meant for the navigation beside it. */
+  pointer-events: none;
+  transform-origin: left center;
+  transition: transform 200ms ease;
 }
 
 /* A 118px logo at the top of the window is most of a phone screen and a good deal of a laptop one,
    so once the bar is stuck it gives up its height to the content behind it. The links stay put:
    Bootstrap centres them against the brand, so the bar closes up around them. */
-.navbar-stuck .navbar-brand .atlaslogo {
+.navbar-stuck .navbar-brand {
   height: 44px;
+  width: 50.5794px;
+}
+
+.navbar-stuck .navbar-brand .atlaslogo {
+  transform: scale(0.3728813559322034);
 }
 
 /* The mark carries no background of its own, so on the dark theme its one shape that touches the
@@ -1462,13 +1509,24 @@ table.countrystats th[scope="row"] {
    block that used to be here worked around bootstrap 3 having no toggle at all, so the eight links
    plus a floated logo filled an entire screen before any content. */
 @media (max-width: 991.98px) {
+  .navbar-brand,
   .navbar-brand .atlaslogo {
     height: 56px;
   }
 
-  /* after the rule above, so it is this one that applies when both match */
-  .navbar-stuck .navbar-brand .atlaslogo {
+  .navbar-brand {
+    width: 64.3738px;
+  }
+
+  /* after the rule above, so it is this one that applies when both match. 56 x (1 - 38/56) = 18,
+     the distance the box falls, so the mark stays inside it for the whole travel here too. */
+  .navbar-stuck .navbar-brand {
     height: 38px;
+    width: 43.6822px;
+  }
+
+  .navbar-stuck .navbar-brand .atlaslogo {
+    transform: scale(0.6785714285714286);
   }
 
   /* The collapsed menu opens inside the sticky bar, and it is a tall menu -- seven links, the
@@ -1578,6 +1636,7 @@ ul.tasks li.task.task-collapsed > .taskinner {
 @media (prefers-reduced-motion: reduce) {
 
   li.task,
+  .navbar-brand,
   .navbar-brand .atlaslogo,
   .navindicator-host.navindicator-animated .navindicator,
   li.task>.taskinner,

--- a/static/main.css
+++ b/static/main.css
@@ -119,6 +119,65 @@ in the query, the -webkit- form included, since that is the only form Safari has
   height: 44px;
 }
 
+/*
+Where it is supported, the mark follows the scroll instead of playing at it.
+
+The stepped behaviour above is the fallback and stays exactly as it is: a class from navbar.js and
+a 200ms transition. It has one trigger point, measured at 2px with the release at 1px, so the
+smallest nudge spends the whole 74px and rocking over that one pixel replays it both ways. And it
+runs on a timer, so three pixels of scrolling cost the same 200ms as eight hundred.
+
+A scroll timeline has no trigger and no timer. The mark is simply a function of how far down the
+page is, so it tracks the scroll under the reader's finger, backwards as readily as forwards, and
+there is no state to toggle and nothing to interrupt.
+
+The range is the mark's own height: by the time the page has moved by as much as the mark is tall,
+the mark has finished shrinking. That is why the two numbers here are the two heights above.
+
+The margin is on the same timeline and the same linear easing, so margin = 118 - height holds at
+every point of the scroll and not only at the two ends. The space the bar occupies is therefore
+constant throughout, which is what keeps the loop described on .navbar-stuck from starting -- and
+it matters more here than it did there, because this drives the height on every frame of a scroll
+rather than twice a page.
+
+Animations beat normal declarations in the cascade, so these override the class-driven values
+without needing to know whether the class is on. navbar.js still adds it, and it still carries the
+border, the shadow and the blur, which belong to the bar being over content rather than to its
+size.
+*/
+@supports (animation-timeline: scroll()) {
+  @keyframes navbar-mark-shrink {
+    from { height: 118px; }
+    to { height: 44px; }
+  }
+
+  @keyframes navbar-space-hold {
+    from { margin-bottom: 0; }
+    to { margin-bottom: 74px; }
+  }
+
+  .navbar-brand .atlaslogo {
+    animation: navbar-mark-shrink linear both;
+    animation-range: 0 118px;
+    animation-timeline: scroll(root block);
+  }
+
+  .navbar {
+    animation: navbar-space-hold linear both;
+    animation-range: 0 118px;
+    animation-timeline: scroll(root block);
+  }
+
+  /* The travel is the decoration, here as above: without it the mark still ends up at both of its
+     sizes, by the class and with no transition. */
+  @media (prefers-reduced-motion: reduce) {
+    .navbar-brand .atlaslogo,
+    .navbar {
+      animation: none;
+    }
+  }
+}
+
 /* The mark carries no background of its own, so on the dark theme its one shape that touches the
    page background -- the leading "a", which sits outside the disc -- is lightened: the brand navy
    is about 2:1 against the dark background, so the wordmark otherwise reads "tlas". The value is
@@ -1508,6 +1567,24 @@ table.countrystats th[scope="row"] {
   /* 56 - 38, the height the mark gives up at this width */
   .navbar.navbar-stuck {
     margin-bottom: 18px;
+  }
+
+  /* the same pair on the scroll timeline; see the block beside the desktop keyframes */
+  @supports (animation-timeline: scroll()) {
+    @keyframes navbar-mark-shrink {
+      from { height: 56px; }
+      to { height: 38px; }
+    }
+
+    @keyframes navbar-space-hold {
+      from { margin-bottom: 0; }
+      to { margin-bottom: 18px; }
+    }
+
+    .navbar-brand .atlaslogo,
+    .navbar {
+      animation-range: 0 56px;
+    }
   }
 
   /* The collapsed menu opens inside the sticky bar, and it is a tall menu -- seven links, the


### PR DESCRIPTION
The mark at the top of the page arrived at its smaller size in jerks on a slow scroll, and smoothly on a fast one. That difference is the whole diagnosis: it was never about how the mark is drawn.

## What was happening

The bar is `position: sticky`, so its box is still page space. Shrinking the mark took 74px out of the document; the browser's scroll anchoring pulled the scroll position back by about as much to hold the content still; and that carried the sentinel above the bar back into view — which is the one thing that tells `navbar.js` the bar is *not* stuck. The class came off, the mark grew again, the document grew with it, and the whole thing went round again.

The trigger sits inside the region that the consequence moves. A fast scroll clears the sentinel in one movement and never gives the loop a second pass, which is why this looked like a rendering fault rather than a loop.

Driving the real page in a browser and scrolling slowly:

| | stuck/unstuck toggles | frames where the mark grew | page moved under the reader |
|---|---|---|---|
| before | 9 | 13 | 48 (max 15px) |
| after | 1 | 0 | 0 |

## The fix

**Hold the bar's page space constant.** The height the mark gives up is handed straight back as `margin-bottom`, so `margin = 118 - height` at every point of the travel. With the space constant there is nothing for scroll anchoring to correct, so the loop cannot start. The document goes from 31 distinct heights during one scroll to 2.

`overflow-anchor: none` on the page also breaks the loop and was measured too. It is worse on both counts: it gives up scroll anchoring for the whole site, and it still lets the document change height, so the page went on jumping by up to 26px. The queue page fills itself in above the viewport, which is exactly what scroll anchoring is for.

**Then let the mark follow the scroll.** The stepped behaviour has one trigger point and a timer — measured at 2px with the release at 1px, so the smallest nudge spent the whole 74px, and rocking over that single pixel replayed it in both directions. Three pixels of scrolling cost the same 200ms as eight hundred.

A scroll timeline has neither. The mark is a function of how far down the page is, so it tracks the scroll under the reader's finger and retraces itself exactly on the way back up. The range is the mark's own height: by the time the page has moved as far as the mark is tall, the mark has finished shrinking.

The margin runs on the same timeline and the same linear easing, so the space stays constant *throughout* and not only at the ends — which matters more here than for the stepped version, because this drives the height on every frame of a scroll rather than twice a page.

## Worth knowing before merging

- **The page now reserves the tall bar's height at the top whether or not the bar is stuck.** Content sits where it sits at rest instead of sliding up under the bar the moment the bar shrinks. That movement was the thing that jerked. At rest the page is pixel-identical to `main`; from about 118px of scroll onward, content sits 74px later in the document than it used to.
- **Older browsers keep the stepped behaviour.** The scroll timeline is behind `@supports (animation-timeline: scroll())`. This stylesheet deliberately supports Safari before 15.4, well before scroll timelines, so the class-and-transition path is live code rather than a leftover — and **it still has the 2px trigger there**. A deadband in `navbar.js` would fix that for everyone and would compose with this; it is not in this PR.
- **`navbar.js` is untouched.** It still adds `navbar-stuck`, which now carries only the border, shadow and blur — those belong to the bar being over content rather than to its size. Animations beat normal declarations in the cascade, so the timeline overrides the class-driven sizes without having to know whether the class is on.
- **The diff is purely additive** — 117 lines added to `static/main.css`, nothing removed. The existing rules are the fallback.

## One commit reverts another

The first commit on this branch replaced the height animation with `transform: scale()`, aimed at the per-frame rasterisation of the mark. That was not the cause. With the loop gone it measures at no difference — both the old height animation and the transform hold a steady 16.7ms frame through the whole travel — so it was reverted. It had cost a fixed `content-box`, a `flex-shrink` guard and four widths derived from the viewBox by hand.

## Test plan

Measured with a browser driving the real page, not by inspection:

- Scrolling down, the mark matches `118 - 74 × (y/118)` to within 0.1px at every sampled position; scrolling back up retraces the same values.
- Height and margin sum to 118.0 throughout, so the document keeps one height.
- The slow scroll that produced 9 toggles and 48 page movements produces 1 and none.
- The same holds at the navbar breakpoint, 56 → 38 over 56px, where `main` jumped the scroll 7 times.
- Settled at rest and scrolled, the page is pixel-identical to `main` at `scrollY = 0`.
- 334 Python and 200 frontend tests pass. No markup changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185958YTiX5eobUEjbdAQv3