### PR TITLE
Record the true origin of an image request, and split the API usage chart

### DIFF
--- a/atlasserver/forcephot/models.py
+++ b/atlasserver/forcephot/models.py
@@ -385,7 +385,7 @@ class Task(models.Model):
             to_attr="live_imagerequests",
         )
 
-    def new_imagerequest(self, user: User) -> "Task":
+    def new_imagerequest(self, user: User, *, from_api: bool) -> "Task":
         """Return an unsaved IMGZIP task that retrieves the images behind this finished FP task.
 
         Here rather than in the view, so that the decision of which fields a child inherits sits
@@ -413,11 +413,11 @@ class Task(models.Model):
             # decides which image directory the remote script reads, so it has to match
             use_reduced=self.use_reduced,
             comment=self.comment,
-            # deliberately False regardless of how the parent was submitted: from_api decides
-            # which maintenance sweep collects the row (31 days for API tasks, 183 otherwise), so
-            # classifying a token-authenticated image request as API would delete it five months
-            # early
-            from_api=False,
+            # the origin of this request, not of the parent: the caller knows which authenticator
+            # accepted the request. from_api selects the maintenance sweep that collects the row
+            # (31 days for API tasks, 183 otherwise); send_email=False below already stops the
+            # result email that from_api would otherwise suppress
+            from_api=from_api,
             send_email=False,
             # the parent's location, kept when the caller cannot place the new request itself
             country_code=self.country_code,

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1205,6 +1205,56 @@ class FromApiDetectionTests(TestCase):
         assert Task.objects.get(id=response.json()["id"]).from_api is True
 
 
+class UsageChartTests(TestCase):
+    """The usage chart splits every series by from_api, so each figure counts its own submitters."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(username="usagechart", email="uc@example.com", password=None)
+        caches["usagestats"].clear()
+
+    def make_task(self, *, from_api: bool, request_type: str) -> Task:
+        return Task.objects.create(
+            user=self.user,
+            ra=1.0,
+            dec=2.0,
+            request_type=request_type,
+            from_api=from_api,
+            finishtimestamp=timezone.now(),
+        )
+
+    def test_the_chart_renders_with_tasks_of_every_origin(self) -> None:
+        for from_api in (True, False):
+            for request_type in ("FP", "IMGZIP"):
+                self.make_task(from_api=from_api, request_type=request_type)
+
+        response = self.client.get(reverse("statsusagechart"))
+
+        assert response.status_code == 200, response.status_code
+        chart = response.json()
+        assert chart["script"]
+        assert chart["div"]
+
+    def test_an_api_image_request_is_counted_on_the_api_figure(self) -> None:
+        # an unfiltered IMGZIP series put every image request on the web figure, so a task that
+        # waited as an API bar moved to the other plot when it finished
+        self.make_task(from_api=True, request_type="IMGZIP")
+
+        response = self.client.get(reverse("statsusagechart"))
+
+        assert response.status_code == 200, response.status_code
+        script = response.json()["script"]
+
+        # the counts reach the browser inside the ColumnDataSource that the script builds. Bokeh
+        # writes each series as a ["name",[...]] pair, and the last column of a series is today
+        def today_count(series: str) -> float:
+            marker = f'["{series}",'
+            assert marker in script, series
+            return json.loads(script.split(marker)[1].split("]")[0] + "]")[-1]
+
+        assert today_count("dayfinished_apiimg_counts") == 1
+        assert today_count("dayfinished_img_counts") == 0
+
+
 # the header line of a forced photometry result file. Module level because two unrelated test
 # classes build result files from it, and reaching across for another class's attribute made the
 # coupling invisible to a reader of either one.
@@ -1518,7 +1568,7 @@ class RequestImagesTests(TestCase):
         answer is an IntegrityError rather than a validation error.
         """
         parent = Task.objects.create(user=self.user, ra=1.0, dec=2.0, request_type="FP", finishtimestamp=timezone.now())
-        child = parent.new_imagerequest(user=self.user)
+        child = parent.new_imagerequest(user=self.user, from_api=False)
         child.save()
 
         self.client.force_login(self.user)
@@ -1555,11 +1605,34 @@ class RequestImagesTests(TestCase):
         assert response.status_code == 302, response.status_code
         imagerequest = Task.objects.get(parent_task_id=task.id)
         assert imagerequest.request_type == "IMGZIP"
-        # from_api selects the retention sweep (31 days for API tasks against 183), so an image
-        # request must stay a web request however its parent was submitted
+        # force_login authenticates with a session cookie, which is what the queue page sends
         assert imagerequest.from_api is False
         assert imagerequest.user_id == self.user.pk
         assert imagerequest.finishtimestamp is None
+
+    def test_a_token_authenticated_image_request_is_from_api(self) -> None:
+        # this endpoint accepts a token like the rest of the API, so it used to file every image
+        # request a script made as a web task: the API figure of the usage chart lost them, and
+        # they were kept for 183 days rather than the 31 days that API tasks get
+        from rest_framework.authtoken.models import Token
+
+        token = Token.objects.create(user=self.user)
+        task = Task.objects.create(user=self.user, ra=1.0, dec=2.0, finishtimestamp=timezone.now())
+        with tempfile.TemporaryDirectory() as tmpdir, override_settings(STATIC_ROOT=tmpdir):
+            resultfile = Path(tmpdir, f"{task.localresultfileprefix()}.txt")
+            resultfile.parent.mkdir(parents=True, exist_ok=True)
+            resultfile.touch()
+
+            response = self.client.post(
+                reverse("requestimages", args=[task.id]),
+                HTTP_ACCEPT="application/json",
+                HTTP_AUTHORIZATION=f"Token {token.key}",
+            )
+
+        assert response.status_code == 302, response.status_code
+        imagerequest = Task.objects.get(parent_task_id=task.id)
+        assert imagerequest.request_type == "IMGZIP"
+        assert imagerequest.from_api is True
 
     def test_the_parents_completion_callback_is_not_inherited(self) -> None:
         # model_to_dict copies every editable field of the parent, so the image request used to

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -615,7 +615,7 @@ class RequestImages(APIView):
 
         if not parent_task.error_msg and parent_task.finishtimestamp:
             # which fields the child inherits is the model's decision; see Task.new_imagerequest
-            newtask = parent_task.new_imagerequest(user=request.user)
+            newtask = parent_task.new_imagerequest(user=request.user, from_api=request_is_from_api(request))
             for field, value in client_location_fields(self.request).items():
                 setattr(newtask, field, value)
             newtask.queuepos_relative = next_queuepos_relative()
@@ -719,7 +719,11 @@ def statsusagechart(request):
 
     dayfinished_web_counts = get_days_ago_counts(finishedtasks.filter(from_api=False, request_type="FP"))
     dayfinished_api_counts = get_days_ago_counts(finishedtasks.filter(from_api=True, request_type="FP"))
-    dayfinished_img_counts = get_days_ago_counts(finishedtasks.filter(request_type="IMGZIP"))
+    # each figure shows the image requests that its own submitters made. An unfiltered IMGZIP
+    # series put every image request on the web figure, so a task that waited as a red bar on the
+    # API figure moved to the other plot when it finished
+    dayfinished_img_counts = get_days_ago_counts(finishedtasks.filter(from_api=False, request_type="IMGZIP"))
+    dayfinished_apiimg_counts = get_days_ago_counts(finishedtasks.filter(from_api=True, request_type="IMGZIP"))
 
     data = {
         "queueday": [(today - datetime.timedelta(days=d)).strftime("%b %d") for d in reversed(range(days_back))],
@@ -728,6 +732,7 @@ def statsusagechart(request):
         "dayfinished_web_counts": dayfinished_web_counts,
         "dayfinished_api_counts": dayfinished_api_counts,
         "dayfinished_img_counts": dayfinished_img_counts,
+        "dayfinished_apiimg_counts": dayfinished_apiimg_counts,
     }
 
     datasource = bokeh.plotting.ColumnDataSource(data=data)
@@ -738,7 +743,8 @@ def statsusagechart(request):
         tools=[
             bokeh.models.HoverTool(
                 tooltips=[
-                    ("Finished (API)", "@dayfinished_api_counts"),
+                    ("Finished (API images)", "@dayfinished_apiimg_counts"),
+                    ("Finished (API FP)", "@dayfinished_api_counts"),
                     ("Waiting (API)", "@waitingtaskcount_api"),
                 ],
             )
@@ -754,11 +760,11 @@ def statsusagechart(request):
     fig_api.grid.visible = False
 
     fig_api.vbar_stack(
-        ["waitingtaskcount_api", "dayfinished_api_counts"],
+        ["waitingtaskcount_api", "dayfinished_api_counts", "dayfinished_apiimg_counts"],
         x="queueday",
         source=datasource,
-        color=["red", "lightgrey"],
-        legend_label=["Waiting (API)", "Finished (API)"],
+        color=["red", "lightgrey", "blue"],
+        legend_label=["Waiting (API)", "Finished (API FP)", "Finished (API images)"],
         line_width=0.0,
         width=0.3,
     )


### PR DESCRIPTION
## What changed

`Task.new_imagerequest()` set `from_api=False` for every IMGZIP task. The `requestimages` endpoint is a DRF `APIView` that accepts a token like the rest of the API, so an image request that a script made was recorded as a web request.

`new_imagerequest()` now takes `from_api` as a keyword argument. `RequestImages.post` supplies `request_is_from_api()`, the same helper that the FP path uses. The viewset POST path needed no change, because `perform_create` already set the field correctly for an IMGZIP task that a caller submitted to the task list.

The usage chart (`statsusagechart`) compounded the fault: the finished IMGZIP series had no `from_api` filter and went on the **Web** figure. An image request from the API showed as a red "Waiting (API)" bar on the top plot, then moved to a blue bar on the bottom plot when it finished. The chart now divides the finished IMGZIP tasks by origin. The API figure carries a third blue bar for the image requests from the API. The label "Finished (API)" becomes "Finished (API FP)", to agree with "Finished (web FP)" below it.

## Why

The origin of a task controls more than a statistic. It selects the maintenance sweep, and it suppresses the result email. An image request from a script was invisible on the API figure of the usage chart.

## For the reviewer

An image request from the API now goes to the 31 day hard-delete sweep, not to the 183 day sweep. This is intentional, and it agrees with the FP tasks from the API. The results have a 14 day soft sweep already, thus this change only removes the archived row earlier.

The email behaviour does not change. `new_imagerequest()` sets `send_email=False` for each image request.

## Tests

Three new tests:

- a POST to `requestimages` with token authentication, which asserts `from_api is True`;
- a new `UsageChartTests` class, which gives the chart its first coverage. One test renders the chart. The other test reads the counts back out of the bokeh `ColumnDataSource`, and asserts that an image request from the API goes to the API series and not to the web series.

The second test fails if the filter goes back to its previous form. Thus it holds the correction, and does not only pass.

All 337 tests pass. `ruff` and `ty` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)