### PR TITLE
Draw the usage chart as one mirrored pair, and fix its colours

### DIFF
--- a/atlasserver/forcephot/templates/stats.html
+++ b/atlasserver/forcephot/templates/stats.html
@@ -10,8 +10,6 @@
 
     <p>There {%if queuedtaskcount != 1 %}are {{ queuedtaskcount }} unfinished tasks{% else %}is {{ queuedtaskcount }} unfinished task{% endif %} in the queue with the most recent completion at <span id="lastfinishtime">{{ lastfinishtime }}</span> (as of <span id="pagetime">{% now "H:i:s" %}</span>).</p>
     <div id="statsshortterm">Loading short term stats...</div>
-    {# margin rather than padding for the spacing above and below: on the dark theme the chart #}
-    {# container is given a background of its own (see main.css), and padding would be inside it #}
     <div id="statsusagechart" style="max-width: 60em; margin-top: 1em; margin-bottom: 2em;">Loading usage chart...</div>
     <div id="statslongterm">Loading long term stats...</div>
     <div style="clear: both">&nbsp;</div>
@@ -51,19 +49,13 @@
       fetch(url, { credentials: 'same-origin' })
         .then((response) => response.ok ? response.json() : Promise.reject(response.status))
         .then((result) => {
-          document.getElementById(elementid).innerHTML = result.div;
-          // The payload's script tag has to be rebuilt rather than assigned as innerHTML: a
-          // <script> inserted that way is inert, so the chart would never draw. jQuery did this
-          // rebuilding internally, which is why the version this replaced could just pass a string.
-          const parsed = new DOMParser().parseFromString(result.script, 'text/html');
-          for (const source of parsed.querySelectorAll('script')) {
-            const script = document.createElement('script');
-            for (const attr of source.attributes) {
-              script.setAttribute(attr.name, attr.value);
-            }
-            script.textContent = source.textContent;
-            document.head.appendChild(script);
-          }
+          const element = document.getElementById(elementid);
+          // the "Loading..." placeholder: embed_item adds the chart to this element, and does not
+          // empty it first
+          element.textContent = '';
+          // bokeh draws the chart into a canvas and takes its colours from the models in the
+          // payload, so the theme has to reach it before it is built
+          return Bokeh.embed.embed_item(window.atlasTheme.themeBokehItem(result.item), elementid);
         })
         .catch((err) => { document.getElementById(elementid).textContent = 'Could not load this chart.'; console.log(url, err); });
     }

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1304,12 +1304,12 @@ class UsageChartTests(TestCase):
         assert self.today_count(item, "api_fp") == 1
         assert self.today_count(item, "api_stall") == 0
 
-    def test_each_half_is_drawn_against_its_own_peak(self) -> None:
+    def test_each_half_is_drawn_against_its_own_scale(self) -> None:
         """The two halves are on their own scales, so neither flattens the other.
 
-        Both reach the same distance from the zero line on their busiest day, however many tasks
-        that day held. The tick labels are what say that those two distances are not the same
-        number of tasks.
+        A hundred API tasks and one web task both land on a round top tick, so both halves reach
+        the same distance from the zero line on their busiest day. The tick labels are what say
+        that those two distances are not the same number of tasks.
         """
         for _ in range(100):
             self.make_task(from_api=True)
@@ -1320,6 +1320,16 @@ class UsageChartTests(TestCase):
         # only the photometry series has tasks here, so its far edge is the end of the stack
         assert abs(self.today_count(item, "api_fp_far") - 1.0) < 1e-9
         assert abs(self.today_count(item, "web_fp_far") + 1.0) < 1e-9
+
+    def test_the_tallest_bar_stops_below_the_top_gridline(self) -> None:
+        # the room this leaves at the top of each half is where the name of that half is written
+        for _ in range(90):
+            self.make_task(from_api=True)
+
+        item = self.chart()
+
+        # 90 tasks against a top gridline of 100
+        assert self.today_count(item, "api_fp_far") < 0.95
 
     def test_the_two_halves_do_not_meet_at_the_zero_line(self) -> None:
         # without the gap a day reads as one bar through the axis rather than as two
@@ -1347,10 +1357,14 @@ class UsageChartTickTests(SimpleTestCase):
             labels = [f"{tick:,.0f}" for tick in ticks]
             assert len(labels) == len(set(labels)), (peak, labels)
 
-    def test_no_tick_is_drawn_past_the_peak_of_its_half(self) -> None:
-        # a tick above the peak sits beyond the end of the half, where the y range does not reach
+    def test_the_top_tick_is_the_first_round_number_above_the_peak(self) -> None:
+        # the half is drawn against its top tick, so that tick has to hold the peak, and it has to
+        # stay near it or the tallest bar of the half is drawn as a stub
         for peak in range(1, 400):
-            assert _usage_arm_ticks(peak)[-1] <= peak, peak
+            top = _usage_arm_ticks(peak)[-1]
+
+            assert top >= peak, peak
+            assert top < 2 * peak, peak
 
     def test_the_ladder_is_coarse_enough_to_read(self) -> None:
         for peak in range(1, 10000):

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1341,9 +1341,9 @@ class UsageChartTests(TestCase):
 
         item = self.chart()
 
-        # only the photometry series has tasks here, so its far edge is the end of the stack
-        assert abs(self.today_count(item, "api_fp_far") - 1.0) < 1e-9
-        assert abs(self.today_count(item, "web_fp_far") + 1.0) < 1e-9
+        # the cap is the last stretch of a stack, so its far edge is where the stack ends
+        assert abs(self.today_count(item, "api_cap_far") - 1.0) < 1e-9
+        assert abs(self.today_count(item, "web_cap_far") + 1.0) < 1e-9
 
     def test_the_tallest_bar_stops_below_the_top_gridline(self) -> None:
         # the room this leaves at the top of each half is where the name of that half is written
@@ -1354,6 +1354,30 @@ class UsageChartTests(TestCase):
 
         # 90 tasks against a top gridline of 100
         assert self.today_count(item, "api_fp_far") < 0.95
+
+    def test_the_outermost_segment_is_drawn_by_the_cap(self) -> None:
+        # only then can the corners the stack ends with be rounded. A cap over part of that segment
+        # would round its corners onto the square end underneath, which is the same colour.
+        for _ in range(100):
+            self.make_task(from_api=True)
+
+        item = self.chart()
+
+        # photometry is the only series here, so the cap is the whole of that day's stack
+        assert self.today_count(item, "api_fp_near") == self.today_count(item, "api_fp_far")
+        assert self.today_count(item, "api_cap_near") == self.today_count(item, "api_fp_near")
+
+    def test_the_cap_is_the_outermost_segment_and_no_more(self) -> None:
+        # a taller one would cover the segment below as well, and show its colour for that day
+        for _ in range(100):
+            self.make_task(from_api=True, request_type="FP")
+        self.make_task(from_api=True, request_type="IMGZIP")
+
+        item = self.chart()
+
+        # the image series is outermost, so the photometry beneath it is drawn in full
+        assert self.today_count(item, "api_cap_near") == self.today_count(item, "api_img_near")
+        assert self.today_count(item, "api_fp_far") == self.today_count(item, "api_img_near")
 
     def test_the_two_halves_do_not_meet_at_the_zero_line(self) -> None:
         # without the gap a day reads as one bar through the axis rather than as two

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -55,6 +55,7 @@ from atlasserver.forcephot.queue import calculate_queue_positions
 from atlasserver.forcephot.serializers import ForcePhotTaskSerializer
 from atlasserver.forcephot.serializers import is_finite_float
 from atlasserver.forcephot.throttles import ForcedPhotRateThrottle
+from atlasserver.forcephot.views import _usage_arm_ticks
 from atlasserver.forcephot.views import geoip_reader
 from atlasserver.forcephot.views import geoip_reader_forget
 from atlasserver.forcephot.webhooks import CallbackUrlError
@@ -1206,21 +1207,45 @@ class FromApiDetectionTests(TestCase):
 
 
 class UsageChartTests(TestCase):
-    """The usage chart splits every series by from_api, so each figure counts its own submitters."""
+    """The usage chart mirrors two halves about a day axis, each on its own scale.
+
+    Every series is split by from_api, so each half counts its own submitters, and the unfinished
+    tasks are split again on attempt_count.
+    """
 
     def setUp(self) -> None:
         self.user = User.objects.create_user(username="usagechart", email="uc@example.com", password=None)
         caches["usagestats"].clear()
 
-    def make_task(self, *, from_api: bool, request_type: str) -> Task:
+    def make_task(self, *, from_api: bool, request_type: str = "FP", finished: bool = True, attempts: int = 0) -> Task:
         return Task.objects.create(
             user=self.user,
             ra=1.0,
             dec=2.0,
             request_type=request_type,
             from_api=from_api,
-            finishtimestamp=timezone.now(),
+            attempt_count=attempts,
+            finishtimestamp=timezone.now() if finished else None,
         )
+
+    def chart(self) -> str:
+        """Return the chart as the page receives it, as one string to search."""
+        response = self.client.get(reverse("statsusagechart"))
+
+        assert response.status_code == 200, response.status_code
+
+        return json.dumps(response.json()["item"])
+
+    def today_count(self, item: str, series: str) -> float:
+        """Return today's value of one series of the ColumnDataSource.
+
+        Bokeh writes each series as a ["name", [...]] pair, and the last column of a series is
+        today.
+        """
+        marker = f'["{series}", '
+        assert marker in item, series
+
+        return json.loads(item.split(marker, maxsplit=1)[1].split("]", maxsplit=1)[0] + "]")[-1]
 
     def test_the_chart_renders_with_tasks_of_every_origin(self) -> None:
         for from_api in (True, False):
@@ -1230,29 +1255,109 @@ class UsageChartTests(TestCase):
         response = self.client.get(reverse("statsusagechart"))
 
         assert response.status_code == 200, response.status_code
-        chart = response.json()
-        assert chart["script"]
-        assert chart["div"]
+        item = response.json()["item"]
+        assert item["doc"]
+        assert item["root_id"]
 
-    def test_an_api_image_request_is_counted_on_the_api_figure(self) -> None:
-        # an unfiltered IMGZIP series put every image request on the web figure, so a task that
-        # waited as an API bar moved to the other plot when it finished
-        self.make_task(from_api=True, request_type="IMGZIP")
-
+    def test_the_chart_renders_with_no_tasks_at_all(self) -> None:
+        # every peak is then zero, which is the divisor each half is scaled by
         response = self.client.get(reverse("statsusagechart"))
 
         assert response.status_code == 200, response.status_code
-        script = response.json()["script"]
 
-        # the counts reach the browser inside the ColumnDataSource that the script builds. Bokeh
-        # writes each series as a ["name",[...]] pair, and the last column of a series is today
-        def today_count(series: str) -> float:
-            marker = f'["{series}",'
-            assert marker in script, series
-            return json.loads(script.split(marker)[1].split("]")[0] + "]")[-1]
+    def test_an_api_image_request_is_counted_on_the_api_half(self) -> None:
+        # an unfiltered IMGZIP series put every image request on the web half, so a task that
+        # waited on the API side moved across when it finished
+        self.make_task(from_api=True, request_type="IMGZIP")
 
-        assert today_count("dayfinished_apiimg_counts") == 1
-        assert today_count("dayfinished_img_counts") == 0
+        item = self.chart()
+
+        assert self.today_count(item, "api_img") == 1
+        assert self.today_count(item, "web_img") == 0
+
+    def test_a_finished_solar_system_stack_stays_on_the_chart(self) -> None:
+        # The two unfinished series count a task of any type. A type that no finished series
+        # counted would therefore leave the queued band and reappear nowhere, and the total of
+        # that day would fall as its tasks finished.
+        self.make_task(from_api=True, request_type="SSOSTACK")
+
+        item = self.chart()
+
+        assert self.today_count(item, "api_img") == 1
+
+    def test_a_task_the_runner_gave_up_on_is_told_from_one_that_is_waiting_its_turn(self) -> None:
+        # the two say different things about the server: a queue is busy, a task the runner started
+        # and did not finish is a fault
+        self.make_task(from_api=True, finished=False, attempts=0)
+        self.make_task(from_api=True, finished=False, attempts=3)
+
+        item = self.chart()
+
+        assert self.today_count(item, "api_queue") == 1
+        assert self.today_count(item, "api_stall") == 1
+
+    def test_a_finished_task_counts_as_finished_however_many_attempts_it_took(self) -> None:
+        self.make_task(from_api=True, finished=True, attempts=4)
+
+        item = self.chart()
+
+        assert self.today_count(item, "api_fp") == 1
+        assert self.today_count(item, "api_stall") == 0
+
+    def test_each_half_is_drawn_against_its_own_peak(self) -> None:
+        """The two halves are on their own scales, so neither flattens the other.
+
+        Both reach the same distance from the zero line on their busiest day, however many tasks
+        that day held. The tick labels are what say that those two distances are not the same
+        number of tasks.
+        """
+        for _ in range(100):
+            self.make_task(from_api=True)
+        self.make_task(from_api=False)
+
+        item = self.chart()
+
+        # only the photometry series has tasks here, so its far edge is the end of the stack
+        assert abs(self.today_count(item, "api_fp_far") - 1.0) < 1e-9
+        assert abs(self.today_count(item, "web_fp_far") + 1.0) < 1e-9
+
+    def test_the_two_halves_do_not_meet_at_the_zero_line(self) -> None:
+        # without the gap a day reads as one bar through the axis rather than as two
+        self.make_task(from_api=True)
+        self.make_task(from_api=False)
+
+        item = self.chart()
+
+        assert self.today_count(item, "api_fp_near") > 0.0
+        assert self.today_count(item, "web_fp_near") < 0.0
+
+
+class UsageChartTickTests(SimpleTestCase):
+    """The y ticks of one half of the usage chart.
+
+    The labels are written to no decimal place, and they name a number of tasks, so every tick has
+    to be a whole number. The chart is drawn to the peak of its half, so no tick may exceed it.
+    """
+
+    def test_a_step_is_always_a_whole_number_of_tasks(self) -> None:
+        for peak in range(1, 400):
+            ticks = _usage_arm_ticks(peak)
+
+            assert all(float(tick).is_integer() for tick in ticks), (peak, ticks)
+            labels = [f"{tick:,.0f}" for tick in ticks]
+            assert len(labels) == len(set(labels)), (peak, labels)
+
+    def test_no_tick_is_drawn_past_the_peak_of_its_half(self) -> None:
+        # a tick above the peak sits beyond the end of the half, where the y range does not reach
+        for peak in range(1, 400):
+            assert _usage_arm_ticks(peak)[-1] <= peak, peak
+
+    def test_the_ladder_is_coarse_enough_to_read(self) -> None:
+        for peak in range(1, 10000):
+            assert len(_usage_arm_ticks(peak)) <= 6, peak
+
+    def test_a_half_with_no_tasks_has_only_its_zero(self) -> None:
+        assert _usage_arm_ticks(0) == [0.0]
 
 
 # the header line of a forced photometry result file. Module level because two unrelated test

--- a/atlasserver/forcephot/tests.py
+++ b/atlasserver/forcephot/tests.py
@@ -1259,6 +1259,30 @@ class UsageChartTests(TestCase):
         assert item["doc"]
         assert item["root_id"]
 
+    def legend_labels(self, item: str) -> list[str]:
+        """Return the series the legend names, in the order it names them."""
+        return [
+            block.split('"value": "', maxsplit=1)[1].split('"', maxsplit=1)[0]
+            for block in item.split('"name": "LegendItem"')[1:]
+        ]
+
+    def test_a_series_with_no_tasks_is_not_named_in_the_legend(self) -> None:
+        # on a healthy fortnight nothing has been attempted and left unfinished, and a colour that
+        # is nowhere on the chart is not a key to the chart
+        self.make_task(from_api=True, request_type="FP")
+
+        labels = self.legend_labels(self.chart())
+
+        assert labels == ["Finished, photometry"], labels
+
+    def test_a_series_the_other_half_has_tasks_for_is_still_named(self) -> None:
+        self.make_task(from_api=True, request_type="FP")
+        self.make_task(from_api=False, finished=False, attempts=2)
+
+        labels = self.legend_labels(self.chart())
+
+        assert labels == ["Attempted, unfinished", "Finished, photometry"], labels
+
     def test_the_chart_renders_with_no_tasks_at_all(self) -> None:
         # every peak is then zero, which is the divisor each half is scaled by
         response = self.client.get(reverse("statsusagechart"))

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -978,9 +978,14 @@ def statsusagechart(request):
     # frame: moved to the panel above the frame it left the frame no height at all, and the chart
     # drew as a legend over an axis.
     legend = bokeh.models.Legend(location="top_left", orientation="horizontal", border_line_width=0)
+    # A series with no tasks in the fortnight is left out of it. On a healthy fortnight the runner
+    # has attempted nothing and left it unfinished, and a colour that is nowhere on the chart is
+    # not a key to the chart. Both halves are counted: a series the web form has no tasks for is
+    # still named while the API has some.
     legend.items = [
         bokeh.models.LegendItem(label=label, renderers=[bar])
-        for (_key, label, _color), bar in zip(reversed(USAGE_SERIES), reversed(bars["api"]), strict=True)
+        for (key, label, _color), bar in zip(reversed(USAGE_SERIES), reversed(bars["api"]), strict=True)
+        if any(sum(counts[origin][key]) for origin in counts)
     ]
     plot.add_layout(legend)
 

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -667,6 +667,10 @@ def statscoordchart(request):
 
     plot.grid.visible = False
 
+    # The toolbar of this figure is inside a shadow root, which no rule in main.css can reach. The
+    # logo therefore goes here, where bokeh builds the toolbar.
+    plot.toolbar.logo = None
+
     rcirc = plot.circle(
         "ra", "dec", source=source, color="white", radius=0.05, hover_color="orange", alpha=0.7, hover_alpha=1.0
     )
@@ -776,13 +780,9 @@ def statsusagechart(request):
             "stall": get_days_ago_counts(unfinished.filter(from_api=from_api, attempt_count__gte=1)),
         }
 
-    # The two halves do not share a scale. Each is drawn against its own peak, and the tick labels
-    # below name the tasks that each half stands for.
-    #
-    # The API side is the larger of the two, and by a margin that moves: it carries about a hundred
-    # times the forced photometry of the web form, but only about four times the tasks of all types,
-    # because most image requests come from the web form. A shared scale would therefore be legible
-    # on some fortnights and flatten the web half on others.
+    # The API carries about a hundred times the traffic of the web form, so the two halves cannot
+    # share a scale: on one axis the web bars are a line on the floor. Each half is therefore drawn
+    # against its own peak, and the tick labels below name the tasks that each half stands for.
     peaks = {
         origin: max(sum(series[day] for series in counts[origin].values()) for day in range(days_back))
         for origin in counts

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -710,6 +710,10 @@ USAGE_SERIES = (
 # two arms meet, and one day reads as a single bar through the axis rather than as two.
 USAGE_ARM_SPLIT = 0.045
 
+# The page left between one segment of a stack and the next, in the same units. About two pixels at
+# the height the chart is drawn at.
+USAGE_SEGMENT_GAP = 0.012
+
 
 def _usage_arm_ticks(peak: float) -> list[float]:
     """Return the tick values from 0 to the first round number at or above `peak`, in tasks.
@@ -799,15 +803,33 @@ def statsusagechart(request):
         top = armticks[origin][-1]
         # the axis units that one task is worth in this half, after the gap at the zero line
         unit = (1.0 - USAGE_ARM_SPLIT) / top if top else 0.0
-        running = [USAGE_ARM_SPLIT] * days_back
 
+        # the hover tool reads the tasks, and the bars read the axis units they are drawn in
         for key, _label, _color in USAGE_SERIES:
-            below = running
-            running = [edge + count * unit for edge, count in zip(below, counts[origin][key], strict=True)]
-            # the hover tool reads the tasks, and the bars read the axis units they are drawn in
             data[f"{origin}_{key}"] = counts[origin][key]
-            data[f"{origin}_{key}_near"] = [direction * edge for edge in below]
-            data[f"{origin}_{key}_far"] = [direction * edge for edge in running]
+            data[f"{origin}_{key}_near"] = []
+            data[f"{origin}_{key}_far"] = []
+
+        for day in range(days_back):
+            edge = USAGE_ARM_SPLIT
+            drawn = False
+
+            for key, _label, _color in USAGE_SERIES:
+                count = counts[origin][key][day]
+                start, edge = edge, edge + count * unit
+
+                if count <= 0:
+                    # nothing to draw, and no gap either: the next segment starts where this one did
+                    near = far = start
+                else:
+                    # a strip of page between one segment and the last, so that a boundary between
+                    # two of them is never colour straight onto colour
+                    near = min(start + USAGE_SEGMENT_GAP, edge) if drawn else start
+                    far = edge
+                    drawn = True
+
+                data[f"{origin}_{key}_near"].append(direction * near)
+                data[f"{origin}_{key}_far"].append(direction * far)
 
     datasource = bokeh.plotting.ColumnDataSource(data=data)
 
@@ -832,10 +854,21 @@ def statsusagechart(request):
     # the day boundaries do not
     plot.xgrid.visible = False
 
+    # No box around the frame, and no rule or ticks along either axis: the gridlines carry the
+    # scale, and a second set of lines around them marks nothing. theme.js colours the lines a
+    # chart draws and leaves alone the ones it is given no colour for, so these stay off.
+    plot.outline_line_color = None
+    plot.axis.axis_line_color = None
+    plot.axis.major_tick_line_color = None
+    plot.axis.minor_tick_line_color = None
+
     # the bars of each half, in the order they stack away from the zero line
     bars: dict[str, list[Any]] = {}
 
     for origin in ("api", "web"):
+        # the corners of a segment that face away from the zero line, which are the ones the end of
+        # a stack is capped with
+        outer = "top" if origin == "api" else "bottom"
         bars[origin] = [
             plot.vbar(
                 x="queueday",
@@ -844,7 +877,8 @@ def statsusagechart(request):
                 source=datasource,
                 color=color,
                 line_width=0.0,
-                width=0.52,
+                width=0.55,
+                border_radius={f"{outer}_left": 3, f"{outer}_right": 3},
             )
             for key, _label, color in USAGE_SERIES
         ]
@@ -901,7 +935,7 @@ def statsusagechart(request):
     legend = bokeh.models.Legend(location="top_left", orientation="horizontal", border_line_width=0)
     legend.items = [
         bokeh.models.LegendItem(label=label, renderers=[bar])
-        for (_key, label, _color), bar in zip(USAGE_SERIES, bars["api"], strict=True)
+        for (_key, label, _color), bar in zip(reversed(USAGE_SERIES), reversed(bars["api"]), strict=True)
     ]
     plot.add_layout(legend)
 

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -710,9 +710,7 @@ USAGE_SERIES = (
 # two arms meet, and one day reads as a single bar through the axis rather than as two.
 USAGE_ARM_SPLIT = 0.031
 
-# The end of a stack is drawn a second time, in the colour of its outermost series, so that its
-# corners can be rounded. This is the height of that cap and the radius of those corners.
-USAGE_CAP = 0.04
+# The radius of the corners a stack ends with.
 USAGE_CAP_RADIUS = 3
 
 
@@ -805,39 +803,53 @@ def statsusagechart(request):
         # the axis units that one task is worth in this half, after the gap at the zero line
         unit = (1.0 - USAGE_ARM_SPLIT) / top if top else 0.0
 
-        running = [USAGE_ARM_SPLIT] * days_back
-
+        # the hover tool reads the tasks, and the bars read the axis units they are drawn in
         for key, _label, _color in USAGE_SERIES:
-            below = running
-            running = [edge + count * unit for edge, count in zip(below, counts[origin][key], strict=True)]
-            # the hover tool reads the tasks, and the bars read the axis units they are drawn in
             data[f"{origin}_{key}"] = counts[origin][key]
-            data[f"{origin}_{key}_near"] = [direction * edge for edge in below]
-            data[f"{origin}_{key}_far"] = [direction * edge for edge in running]
+            data[f"{origin}_{key}_near"] = []
+            data[f"{origin}_{key}_far"] = []
 
-        # The end of the stack, in the colour of the outermost series that has any tasks that day.
-        # bokeh gives a renderer one border_radius for all of its bars, so a stack cannot be capped
-        # by rounding whichever of its four segments happens to be the outermost one that day. It
-        # is capped by drawing that segment's end again, over the square end beneath it.
+        # The outermost segment of a stack is drawn by a bar of its own, so that the corners it
+        # ends with can be rounded: bokeh gives a renderer one border_radius for all of its bars,
+        # and which of the four series is outermost changes from day to day.
+        #
+        # It is the whole segment and not the last stretch of it. A bar that covered only the end
+        # would round its corners onto the square end underneath, which is the same colour, and the
+        # stack would still end square; a bar that stopped just short of it would leave a hairline
+        # of page between the two.
         capcolor: list[str] = []
         capnear: list[float] = []
+        capfar: list[float] = []
+
         for day in range(days_back):
-            cap = 0.0
-            color = USAGE_SERIES[0][2]
+            edge = USAGE_ARM_SPLIT
+            outermost = None
 
-            for key, _label, seriescolor in reversed(USAGE_SERIES):
+            for key, _label, seriescolor in USAGE_SERIES:
                 count = counts[origin][key][day]
-                if count > 0:
-                    # no taller than the segment it caps, or it would paint over the one below
-                    color, cap = seriescolor, min(USAGE_CAP, count * unit)
-                    break
+                start, edge = edge, edge + count * unit
+                data[f"{origin}_{key}_near"].append(direction * start)
+                data[f"{origin}_{key}_far"].append(direction * edge)
 
-            capcolor.append(color)
-            capnear.append(direction * (running[day] - cap))
+                if count > 0:
+                    outermost = (key, start, seriescolor)
+
+            if outermost is None:
+                # a day with no tasks at all: there is no segment to end, and nothing is drawn
+                capcolor.append(USAGE_SERIES[0][2])
+                capnear.append(direction * edge)
+                capfar.append(direction * edge)
+                continue
+
+            key, start, seriescolor = outermost
+            data[f"{origin}_{key}_far"][day] = direction * start
+            capcolor.append(seriescolor)
+            capnear.append(direction * start)
+            capfar.append(direction * edge)
 
         data[f"{origin}_cap_color"] = capcolor
         data[f"{origin}_cap_near"] = capnear
-        data[f"{origin}_cap_far"] = [direction * edge for edge in running]
+        data[f"{origin}_cap_far"] = capfar
 
     datasource = bokeh.plotting.ColumnDataSource(data=data)
 
@@ -851,7 +863,10 @@ def statsusagechart(request):
         # the chart drew as a legend over an axis. A height it is given needs no solving.
         sizing_mode="stretch_width",
         height=430,
-        output_backend="svg",
+        # canvas rather than svg: bokeh's svg backend raises "not implemented" from roundRect, so
+        # the cap that rounds the end of a stack draws as a square corner there. Nothing here asks
+        # for vector output -- this figure has no toolbar, and so no save button
+        output_backend="canvas",
         # transparent, so the figure sits on the page and follows the theme with it. theme.js
         # colours the axes, the gridlines, the legend, the names of the halves and the zero line
         background_fill_color=None,

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -708,17 +708,18 @@ USAGE_SERIES = (
 
 # The part of each half of statsusagechart that is left empty next to the zero line. Without it the
 # two arms meet, and one day reads as a single bar through the axis rather than as two.
-USAGE_ARM_SPLIT = 0.045
+USAGE_ARM_SPLIT = 0.031
 
-# The page left between one segment of a stack and the next, in the same units. About two pixels at
-# the height the chart is drawn at.
-USAGE_SEGMENT_GAP = 0.012
+# The end of a stack is drawn a second time, in the colour of its outermost series, so that its
+# corners can be rounded. This is the height of that cap and the radius of those corners.
+USAGE_CAP = 0.04
+USAGE_CAP_RADIUS = 3
 
 
 def _usage_arm_ticks(peak: float) -> list[float]:
     """Return the tick values from 0 to the first round number at or above `peak`, in tasks.
 
-    The step is 1, 2, 2.5 or 5 times a power of ten, whichever first gives four or fewer steps.
+    The step is 1, 2, 2.5 or 5 times a power of ten, whichever first gives three or fewer steps.
 
     A step must be a whole number of tasks, so the magnitude stops at one and a step of 2.5 is
     passed over. A fraction of a task cannot be labelled: the labels are written to no decimal
@@ -730,9 +731,9 @@ def _usage_arm_ticks(peak: float) -> list[float]:
     if peak <= 0:
         return [0.0]
 
-    magnitude = 10 ** max(0, math.floor(math.log10(peak / 4)))
+    magnitude = 10 ** max(0, math.floor(math.log10(peak / 3)))
     step = next(
-        m * magnitude for m in (1, 2, 2.5, 5, 10) if m * magnitude >= peak / 4 and float(m * magnitude).is_integer()
+        m * magnitude for m in (1, 2, 2.5, 5, 10) if m * magnitude >= peak / 3 and float(m * magnitude).is_integer()
     )
 
     return [n * step for n in range(math.ceil(peak / step) + 1)]
@@ -804,38 +805,45 @@ def statsusagechart(request):
         # the axis units that one task is worth in this half, after the gap at the zero line
         unit = (1.0 - USAGE_ARM_SPLIT) / top if top else 0.0
 
-        # the hover tool reads the tasks, and the bars read the axis units they are drawn in
+        running = [USAGE_ARM_SPLIT] * days_back
+
         for key, _label, _color in USAGE_SERIES:
+            below = running
+            running = [edge + count * unit for edge, count in zip(below, counts[origin][key], strict=True)]
+            # the hover tool reads the tasks, and the bars read the axis units they are drawn in
             data[f"{origin}_{key}"] = counts[origin][key]
-            data[f"{origin}_{key}_near"] = []
-            data[f"{origin}_{key}_far"] = []
+            data[f"{origin}_{key}_near"] = [direction * edge for edge in below]
+            data[f"{origin}_{key}_far"] = [direction * edge for edge in running]
 
+        # The end of the stack, in the colour of the outermost series that has any tasks that day.
+        # bokeh gives a renderer one border_radius for all of its bars, so a stack cannot be capped
+        # by rounding whichever of its four segments happens to be the outermost one that day. It
+        # is capped by drawing that segment's end again, over the square end beneath it.
+        capcolor: list[str] = []
+        capnear: list[float] = []
         for day in range(days_back):
-            edge = USAGE_ARM_SPLIT
-            drawn = False
+            cap = 0.0
+            color = USAGE_SERIES[0][2]
 
-            for key, _label, _color in USAGE_SERIES:
+            for key, _label, seriescolor in reversed(USAGE_SERIES):
                 count = counts[origin][key][day]
-                start, edge = edge, edge + count * unit
+                if count > 0:
+                    # no taller than the segment it caps, or it would paint over the one below
+                    color, cap = seriescolor, min(USAGE_CAP, count * unit)
+                    break
 
-                if count <= 0:
-                    # nothing to draw, and no gap either: the next segment starts where this one did
-                    near = far = start
-                else:
-                    # a strip of page between one segment and the last, so that a boundary between
-                    # two of them is never colour straight onto colour
-                    near = min(start + USAGE_SEGMENT_GAP, edge) if drawn else start
-                    far = edge
-                    drawn = True
+            capcolor.append(color)
+            capnear.append(direction * (running[day] - cap))
 
-                data[f"{origin}_{key}_near"].append(direction * near)
-                data[f"{origin}_{key}_far"].append(direction * far)
+        data[f"{origin}_cap_color"] = capcolor
+        data[f"{origin}_cap_near"] = capnear
+        data[f"{origin}_cap_far"] = [direction * edge for edge in running]
 
     datasource = bokeh.plotting.ColumnDataSource(data=data)
 
     plot = bokeh.plotting.figure(
         x_range=bokeh.models.FactorRange(factors=data["queueday"]),
-        y_range=bokeh.models.Range1d(start=-1.2, end=1.2),
+        y_range=bokeh.models.Range1d(start=-1.08, end=1.42),
         tools=[],
         toolbar_location=None,
         # A height in pixels rather than a ratio. The container gives a width and no height, and
@@ -866,9 +874,14 @@ def statsusagechart(request):
     bars: dict[str, list[Any]] = {}
 
     for origin in ("api", "web"):
-        # the corners of a segment that face away from the zero line, which are the ones the end of
-        # a stack is capped with
-        outer = "top" if origin == "api" else "bottom"
+        # The corners of a bar that face away from the zero line, which are the ones a stack is
+        # capped with. In the order bokeh takes them, which is the order CSS takes them: top left,
+        # top right, bottom right, bottom left. A radius is a whole number of pixels.
+        radius = (
+            (USAGE_CAP_RADIUS, USAGE_CAP_RADIUS, 0, 0)
+            if origin == "api"
+            else (0, 0, USAGE_CAP_RADIUS, USAGE_CAP_RADIUS)
+        )
         bars[origin] = [
             plot.vbar(
                 x="queueday",
@@ -877,18 +890,33 @@ def statsusagechart(request):
                 source=datasource,
                 color=color,
                 line_width=0.0,
-                width=0.55,
-                border_radius={f"{outer}_left": 3, f"{outer}_right": 3},
+                width=0.58,
             )
             for key, _label, color in USAGE_SERIES
         ]
 
-        # one hover per half, so a day reports the counts of the half the pointer is over
+        cap = plot.vbar(
+            x="queueday",
+            bottom=f"{origin}_cap_near",
+            top=f"{origin}_cap_far",
+            source=datasource,
+            color=f"{origin}_cap_color",
+            line_width=0.0,
+            width=0.58,
+        )
+        # Through update() rather than as a keyword of vbar() or an assignment on the glyph.
+        # bokeh's own signature for vbar() does not name border_radius, and its type stub gives the
+        # glyph's border_radius the type of the property that holds it rather than the type of a
+        # value for it, so both spellings are rejected by a type checker.
+        cap.glyph.update(border_radius=radius)
+
+        # one hover per half, so a day reports the counts of the half the pointer is over. The cap
+        # answers for the end of the stack, which is the part of a bar a pointer meets first
         plot.add_tools(
             bokeh.models.HoverTool(
                 tooltips=[("Day", "@queueday")]
                 + [(label, f"@{origin}_{key}") for key, label, _color in reversed(USAGE_SERIES)],
-                renderers=bars[origin],
+                renderers=[*bars[origin], cap],
             )
         )
 
@@ -912,22 +940,39 @@ def statsusagechart(request):
     # rather than as the axis of either one.
     plot.add_layout(bokeh.models.Span(location=0.0, dimension="width", line_width=1.5))
 
-    # Each half names itself and its own peak, in the room its top gridline leaves. This is what
-    # keeps a reader from taking the two heights as comparable, so it is not decoration.
-    for origin, name, corner, offset in (("api", "API", "top_right", -6), ("web", "Web", "bottom_right", 6)):
-        plot.add_layout(
-            bokeh.models.Label(
-                x=bokeh.models.Node(target="frame", symbol=corner),
-                y=bokeh.models.Node(target="frame", symbol=corner),
-                x_offset=-6,
-                y_offset=offset,
-                text=f"{name} \u2014 peak {peaks[origin]:,.0f}/day",
-                text_align="right",
-                text_baseline="top" if origin == "api" else "bottom",
-                text_font_size="11px",
-                text_font_style="bold",
-            )
+    # Each half names itself and its own peak. This is what keeps a reader from taking the two
+    # heights as comparable, so it is not decoration.
+    #
+    # The upper name sits in the room the top gridline leaves inside the frame, beside the legend.
+    # The lower one goes under the day labels, which is the axis label's own place: below the
+    # bottom gridline there is only a margin, and a name written in it would sit on the lowest
+    # bars.
+    plot.add_layout(
+        bokeh.models.Label(
+            x=bokeh.models.Node(target="frame", symbol="top_right"),
+            y=bokeh.models.Node(target="frame", symbol="top_right"),
+            x_offset=-6,
+            y_offset=-6,
+            text=f"API \u2014 peak {peaks['api']:,.0f}/day",
+            text_align="right",
+            text_baseline="top",
+            text_font_size="11px",
+            text_font_style="bold",
         )
+    )
+
+    # A title in the panel below the frame, which is the one place under the day labels that text
+    # can go: bokeh clips an annotation to the frame, so a Label here is not drawn at all, and an
+    # axis label is centred on the end of the axis and runs off the right of the chart.
+    plot.add_layout(
+        bokeh.models.Title(
+            text=f"Web \u2014 peak {peaks['web']:,.0f}/day",
+            align="right",
+            text_font_size="11px",
+            text_font_style="bold",
+        ),
+        "below",
+    )
 
     # One legend for the pair, built from the bars of the upper half. It lies along the top of the
     # frame: moved to the panel above the frame it left the frame no height at all, and the chart

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -636,7 +636,7 @@ def statscoordchart(request):
     # serve this endpoint and statsusagechart, both of which are cached for a day
     import bokeh.models
     import bokeh.plotting
-    from bokeh.embed import components
+    from bokeh.embed import json_item
 
     tasks = list(Task.objects.all().order_by("-timestamp")[:20000].select_related("user"))
 
@@ -651,7 +651,10 @@ def statscoordchart(request):
     plot = bokeh.plotting.figure(
         tools="pan,wheel_zoom,box_zoom,reset",
         aspect_ratio=2,
+        # the sky is dark on both themes, but the margin around it takes the colour of the page.
+        # theme.js gives the title, the axes and the outline the colours that go with that page
         background_fill_color="#040154",
+        border_fill_color=None,
         active_scroll="wheel_zoom",
         title="Recently requested coordinates",
         x_axis_label="Right ascension (deg)",
@@ -677,9 +680,54 @@ def statscoordchart(request):
         )
     )
 
-    script, strhtml = components(plot)
+    # json_item rather than components: the page builds the chart itself with
+    # Bokeh.embed.embed_item, which lets theme.js colour the models before bokeh draws them
+    return JsonResponse({"item": json_item(plot)})
 
-    return JsonResponse({"script": script, "div": strhtml})
+
+# The colours of the four series of statsusagechart, from the bottom of a stack outward.
+#
+# These are the data, so they are held here rather than in theme.js with the colours of the frame.
+# One step of each hue serves both themes: each clears the lightness band, the chroma floor and the
+# 3:1 contrast floor against the white page and against the #212529 dark one, and each touching
+# pair separates by dE 8.4 or more under protanopia and deuteranopia.
+#
+# The red is a state and not a fourth series. It marks work the task runner picked up and did not
+# finish, which is a fact about the server rather than a busier version of the queue, so it is held
+# apart from the three hues that carry the ordinary series.
+USAGE_SERIES = (
+    ("fp", "Finished, photometry", "#3987e5"),
+    ("img", "Finished, images", "#199e70"),
+    ("queue", "Queued", "#c98500"),
+    ("stall", "Attempted, unfinished", "#d03b3b"),
+)
+
+# The part of each half of statsusagechart that is left empty next to the zero line. Without it the
+# two arms meet, and one day reads as a single bar through the axis rather than as two.
+USAGE_ARM_SPLIT = 0.045
+
+
+def _usage_arm_ticks(peak: float) -> list[float]:
+    """Return the tick values from 0 up to `peak`, in tasks.
+
+    The step is 1, 2, 2.5 or 5 times a power of ten, whichever first gives four or fewer steps.
+
+    A step must be a whole number of tasks, so the magnitude stops at one and a step of 2.5 is
+    passed over. A fraction of a task cannot be labelled: the labels are written to no decimal
+    place, which put "2" on the tick at 2.5 and "8" on the tick at 7.5.
+
+    The last tick is at or below the peak. A tick above it falls beyond the end of its half of the
+    chart, where the y range does not reach and no label is drawn.
+    """
+    if peak <= 0:
+        return [0.0]
+
+    magnitude = 10 ** max(0, math.floor(math.log10(peak / 4)))
+    step = next(
+        m * magnitude for m in (1, 2, 2.5, 5, 10) if m * magnitude >= peak / 4 and float(m * magnitude).is_integer()
+    )
+
+    return [n * step for n in range(int(peak // step) + 1)]
 
 
 # the same 15 minutes as statsshortterm, which windows over the same data. This was 30 seconds,
@@ -688,10 +736,9 @@ def statscoordchart(request):
 @cache_page(60 * 15, cache="usagestats")
 def statsusagechart(request):
     # deferred: see statscoordchart
-    import bokeh.layouts
     import bokeh.models
     import bokeh.plotting
-    from bokeh.embed import components
+    from bokeh.embed import json_item
 
     days_back = 14
 
@@ -704,116 +751,147 @@ def statsusagechart(request):
         return [dictcounts.get(d, 0.0) for d in reversed(range(days_back))]
 
     today = datetime.datetime.now(datetime.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    windowstart = today - datetime.timedelta(days=days_back)
 
-    waitingtasks = Task.objects.filter(
-        timestamp__gt=today - datetime.timedelta(days=days_back), finishtimestamp__isnull=True
-    )
+    unfinished = Task.objects.filter(timestamp__gt=windowstart, finishtimestamp__isnull=True)
+    finished = Task.objects.filter(timestamp__gt=windowstart, finishtimestamp__isnull=False)
 
-    waitingtasks_api = waitingtasks.filter(from_api=True)
-    waitingtasks_nonapi = waitingtasks.filter(from_api=False)
+    # A task the runner has started at least once and has not finished is a different fact from a
+    # task that is waiting its turn: the first says the runner is letting go of work it picked up.
+    # main.py increments attempt_count as it starts a task, so a count above zero is that signal.
+    counts = {}
+    for origin, from_api in (("api", True), ("web", False)):
+        # Each half of the chart counts the image requests of its own submitters. An unfiltered
+        # IMGZIP series put every image request on the web side, so a task that waited on the API
+        # side moved across when it finished.
+        #
+        # The image series covers every request type that is not forced photometry, which is what
+        # keeps a day's total from falling as its tasks finish: the two unfinished series count a
+        # task of any type, so a type that no finished series counted would leave the queued band
+        # and reappear nowhere. Task.RequestType has a third member, the Solar System image stack.
+        counts[origin] = {
+            "fp": get_days_ago_counts(finished.filter(from_api=from_api, request_type="FP")),
+            "img": get_days_ago_counts(finished.filter(from_api=from_api).exclude(request_type="FP")),
+            "queue": get_days_ago_counts(unfinished.filter(from_api=from_api, attempt_count=0)),
+            "stall": get_days_ago_counts(unfinished.filter(from_api=from_api, attempt_count__gte=1)),
+        }
 
-    daywaitingcounts_api = get_days_ago_counts(waitingtasks_api)
-    daywaitingcounts_nonapi = get_days_ago_counts(waitingtasks_nonapi)
-
-    finishedtasks = Task.objects.filter(
-        timestamp__gt=today - datetime.timedelta(days=days_back), finishtimestamp__isnull=False
-    )
-
-    dayfinished_web_counts = get_days_ago_counts(finishedtasks.filter(from_api=False, request_type="FP"))
-    dayfinished_api_counts = get_days_ago_counts(finishedtasks.filter(from_api=True, request_type="FP"))
-    # each figure shows the image requests that its own submitters made. An unfiltered IMGZIP
-    # series put every image request on the web figure, so a task that waited as a red bar on the
-    # API figure moved to the other plot when it finished
-    dayfinished_img_counts = get_days_ago_counts(finishedtasks.filter(from_api=False, request_type="IMGZIP"))
-    dayfinished_apiimg_counts = get_days_ago_counts(finishedtasks.filter(from_api=True, request_type="IMGZIP"))
-
-    data = {
-        "queueday": [(today - datetime.timedelta(days=d)).strftime("%b %d") for d in reversed(range(days_back))],
-        "waitingtaskcount_api": daywaitingcounts_api,
-        "waitingtaskcount_nonapi": daywaitingcounts_nonapi,
-        "dayfinished_web_counts": dayfinished_web_counts,
-        "dayfinished_api_counts": dayfinished_api_counts,
-        "dayfinished_img_counts": dayfinished_img_counts,
-        "dayfinished_apiimg_counts": dayfinished_apiimg_counts,
+    # The two halves do not share a scale. Each is drawn against its own peak, and the tick labels
+    # below name the tasks that each half stands for.
+    #
+    # The API side is the larger of the two, and by a margin that moves: it carries about a hundred
+    # times the forced photometry of the web form, but only about four times the tasks of all types,
+    # because most image requests come from the web form. A shared scale would therefore be legible
+    # on some fortnights and flatten the web half on others.
+    peaks = {
+        origin: max(sum(series[day] for series in counts[origin].values()) for day in range(days_back))
+        for origin in counts
     }
+
+    data: dict[str, Any] = {
+        "queueday": [(today - datetime.timedelta(days=d)).strftime("%b %d") for d in reversed(range(days_back))]
+    }
+
+    for origin, direction in (("api", 1.0), ("web", -1.0)):
+        peak = peaks[origin]
+        # the axis units that one task is worth in this half, after the gap at the zero line
+        unit = (1.0 - USAGE_ARM_SPLIT) / peak if peak else 0.0
+        running = [USAGE_ARM_SPLIT] * days_back
+
+        for key, _label, _color in USAGE_SERIES:
+            below = running
+            running = [edge + count * unit for edge, count in zip(below, counts[origin][key], strict=True)]
+            # the hover tool reads the tasks, and the bars read the axis units they are drawn in
+            data[f"{origin}_{key}"] = counts[origin][key]
+            data[f"{origin}_{key}_near"] = [direction * edge for edge in below]
+            data[f"{origin}_{key}_far"] = [direction * edge for edge in running]
 
     datasource = bokeh.plotting.ColumnDataSource(data=data)
 
-    fig_api = bokeh.plotting.figure(
+    plot = bokeh.plotting.figure(
+        # the three blank days at the end are the room the legend sits in, so that it covers no
+        # bars. The same trick held the legend of the two figures this replaced
         x_range=bokeh.models.FactorRange(factors=[*data["queueday"], " ", "  ", "   "]),
-        y_range=bokeh.models.DataRange1d(start=0.0),
-        tools=[
-            bokeh.models.HoverTool(
-                tooltips=[
-                    ("Finished (API images)", "@dayfinished_apiimg_counts"),
-                    ("Finished (API FP)", "@dayfinished_api_counts"),
-                    ("Waiting (API)", "@waitingtaskcount_api"),
-                ],
-            )
-        ],
+        y_range=bokeh.models.Range1d(start=-1.06, end=1.06),
+        tools=[],
         toolbar_location=None,
-        aspect_ratio=5,
-        title="API",
-        sizing_mode="stretch_both",
+        # Each half names its own peak here rather than in a corner of the frame. The halves are on
+        # their own scales, so a reader who takes the two heights as comparable reads the chart
+        # wrong; this line, and the tick labels, are what say that they are not.
+        title=(f"API above, peak {peaks['api']:,.0f}/day    \u00b7    Web below, peak {peaks['web']:,.0f}/day"),
+        # A height in pixels rather than a ratio. The container gives a width and no height, and
+        # bokeh solved the first layout of a ratio against it with a frame of no height at all:
+        # the chart drew as a legend over an axis. A height it is given needs no solving.
+        sizing_mode="stretch_width",
+        height=430,
         output_backend="svg",
-        y_axis_label="API tasks per day",
+        # transparent, so the figure sits on the page and follows the theme with it. theme.js
+        # colours the title, the axes, the legend and the zero line to match
+        background_fill_color=None,
+        border_fill_color=None,
     )
 
-    fig_api.grid.visible = False
+    plot.grid.visible = False
 
-    fig_api.vbar_stack(
-        ["waitingtaskcount_api", "dayfinished_api_counts", "dayfinished_apiimg_counts"],
-        x="queueday",
-        source=datasource,
-        color=["red", "green", "blue"],
-        legend_label=["Waiting (API)", "Finished (API FP)", "Finished (API images)"],
-        line_width=0.0,
-        width=0.3,
-    )
+    # the bars of each half, in the order they stack away from the zero line
+    bars: dict[str, list[Any]] = {}
 
-    fig_nonapi = bokeh.plotting.figure(
-        x_range=bokeh.models.FactorRange(factors=[*data["queueday"], " ", "  ", "   "]),
-        y_range=bokeh.models.DataRange1d(start=0.0),
-        tools=[
-            bokeh.models.HoverTool(
-                tooltips=[
-                    ("Finished (web images)", "@dayfinished_img_counts"),
-                    ("Finished (web FP)", "@dayfinished_web_counts"),
-                    ("Waiting (web)", "@waitingtaskcount_nonapi"),
-                ],
+    for origin in ("api", "web"):
+        bars[origin] = [
+            plot.vbar(
+                x="queueday",
+                bottom=f"{origin}_{key}_near",
+                top=f"{origin}_{key}_far",
+                source=datasource,
+                color=color,
+                line_width=0.0,
+                width=0.52,
             )
-        ],
-        toolbar_location=None,
-        aspect_ratio=5,
-        title="Web",
-        sizing_mode="stretch_both",
-        output_backend="svg",
-        y_axis_label="Web tasks per day",
-    )
+            for key, _label, color in USAGE_SERIES
+        ]
 
-    fig_nonapi.vbar_stack(
-        ["waitingtaskcount_nonapi", "dayfinished_web_counts", "dayfinished_img_counts"],
-        x="queueday",
-        source=datasource,
-        color=["red", "green", "blue"],
-        legend_label=["Waiting (web)", "Finished (web FP)", "Finished (web images)"],
-        line_width=0.0,
-        width=0.3,
-    )
+        # one hover per half, so a day reports the counts of the half the pointer is over
+        plot.add_tools(
+            bokeh.models.HoverTool(
+                tooltips=[("Day", "@queueday")]
+                + [(label, f"@{origin}_{key}") for key, label, _color in reversed(USAGE_SERIES)],
+                renderers=bars[origin],
+            )
+        )
 
-    fig_nonapi.legend[0].border_line_width = 0
+    # The ticks of the two halves are the same line of code twice over, but they are not the same
+    # numbers: each half is scaled to its own peak, so a tick at the same height means about a
+    # hundred times more tasks above the axis than below it.
+    tickpositions = [0.0]
+    ticklabels: dict[float | str, Any] = {0.0: "0"}
+    for origin, direction in (("api", 1.0), ("web", -1.0)):
+        peak = peaks[origin]
+        unit = (1.0 - USAGE_ARM_SPLIT) / peak if peak else 0.0
+        for value in _usage_arm_ticks(peak)[1:]:
+            position = direction * (USAGE_ARM_SPLIT + value * unit)
+            tickpositions.append(position)
+            ticklabels[position] = f"{value:,.0f}"
 
-    fig_nonapi.grid.visible = False
+    plot.yaxis.ticker = bokeh.models.FixedTicker(ticks=tickpositions)
+    plot.yaxis.major_label_overrides = ticklabels
 
-    plot = bokeh.layouts.column(
-        [fig_api, fig_nonapi],
-        sizing_mode="stretch_both",
-        aspect_ratio=2.5,
-    )
+    # The zero line is the one thing the two halves share, so it is drawn once and for the pair
+    # rather than as the axis of either one.
+    plot.add_layout(bokeh.models.Span(location=0.0, dimension="width", line_width=1.5))
 
-    script, strhtml = components(plot)
+    # One legend for the pair, built from the bars of the upper half. It stays inside the frame,
+    # in the blank days the x range ends with: moved to the panel above the frame it left the
+    # frame no height at all, and the chart drew as a legend over an axis.
+    legend = bokeh.models.Legend(location="top_right", border_line_width=0)
+    legend.items = [
+        bokeh.models.LegendItem(label=label, renderers=[bar])
+        for (_key, label, _color), bar in zip(USAGE_SERIES, bars["api"], strict=True)
+    ]
+    plot.add_layout(legend)
 
-    return JsonResponse({"script": script, "div": strhtml})
+    # json_item rather than components: the page builds the chart itself with
+    # Bokeh.embed.embed_item, which lets theme.js colour the models before bokeh draws them
+    return JsonResponse({"item": json_item(plot)})
 
 
 @cache_page(60 * 60 * 4, cache="usagestats")

--- a/atlasserver/forcephot/views.py
+++ b/atlasserver/forcephot/views.py
@@ -712,7 +712,7 @@ USAGE_ARM_SPLIT = 0.045
 
 
 def _usage_arm_ticks(peak: float) -> list[float]:
-    """Return the tick values from 0 up to `peak`, in tasks.
+    """Return the tick values from 0 to the first round number at or above `peak`, in tasks.
 
     The step is 1, 2, 2.5 or 5 times a power of ten, whichever first gives four or fewer steps.
 
@@ -720,8 +720,8 @@ def _usage_arm_ticks(peak: float) -> list[float]:
     passed over. A fraction of a task cannot be labelled: the labels are written to no decimal
     place, which put "2" on the tick at 2.5 and "8" on the tick at 7.5.
 
-    The last tick is at or below the peak. A tick above it falls beyond the end of its half of the
-    chart, where the y range does not reach and no label is drawn.
+    The last tick is what its half of the chart is drawn against, and it is at or above the peak.
+    Thus the tallest bar of a half stops below the top gridline rather than at the frame.
     """
     if peak <= 0:
         return [0.0]
@@ -731,7 +731,7 @@ def _usage_arm_ticks(peak: float) -> list[float]:
         m * magnitude for m in (1, 2, 2.5, 5, 10) if m * magnitude >= peak / 4 and float(m * magnitude).is_integer()
     )
 
-    return [n * step for n in range(int(peak // step) + 1)]
+    return [n * step for n in range(math.ceil(peak / step) + 1)]
 
 
 # the same 15 minutes as statsshortterm, which windows over the same data. This was 30 seconds,
@@ -782,20 +782,23 @@ def statsusagechart(request):
 
     # The API carries about a hundred times the traffic of the web form, so the two halves cannot
     # share a scale: on one axis the web bars are a line on the floor. Each half is therefore drawn
-    # against its own peak, and the tick labels below name the tasks that each half stands for.
+    # against its own gridlines, and their labels name the tasks that each half stands for.
     peaks = {
         origin: max(sum(series[day] for series in counts[origin].values()) for day in range(days_back))
         for origin in counts
     }
+    armticks = {origin: _usage_arm_ticks(peak) for origin, peak in peaks.items()}
 
     data: dict[str, Any] = {
         "queueday": [(today - datetime.timedelta(days=d)).strftime("%b %d") for d in reversed(range(days_back))]
     }
 
     for origin, direction in (("api", 1.0), ("web", -1.0)):
-        peak = peaks[origin]
+        # A half is scaled to its top gridline and not to its peak, which is what leaves the room
+        # above the tallest bar that the name of the half is written in.
+        top = armticks[origin][-1]
         # the axis units that one task is worth in this half, after the gap at the zero line
-        unit = (1.0 - USAGE_ARM_SPLIT) / peak if peak else 0.0
+        unit = (1.0 - USAGE_ARM_SPLIT) / top if top else 0.0
         running = [USAGE_ARM_SPLIT] * days_back
 
         for key, _label, _color in USAGE_SERIES:
@@ -809,16 +812,10 @@ def statsusagechart(request):
     datasource = bokeh.plotting.ColumnDataSource(data=data)
 
     plot = bokeh.plotting.figure(
-        # the three blank days at the end are the room the legend sits in, so that it covers no
-        # bars. The same trick held the legend of the two figures this replaced
-        x_range=bokeh.models.FactorRange(factors=[*data["queueday"], " ", "  ", "   "]),
-        y_range=bokeh.models.Range1d(start=-1.06, end=1.06),
+        x_range=bokeh.models.FactorRange(factors=data["queueday"]),
+        y_range=bokeh.models.Range1d(start=-1.2, end=1.2),
         tools=[],
         toolbar_location=None,
-        # Each half names its own peak here rather than in a corner of the frame. The halves are on
-        # their own scales, so a reader who takes the two heights as comparable reads the chart
-        # wrong; this line, and the tick labels, are what say that they are not.
-        title=(f"API above, peak {peaks['api']:,.0f}/day    \u00b7    Web below, peak {peaks['web']:,.0f}/day"),
         # A height in pixels rather than a ratio. The container gives a width and no height, and
         # bokeh solved the first layout of a ratio against it with a frame of no height at all:
         # the chart drew as a legend over an axis. A height it is given needs no solving.
@@ -826,12 +823,14 @@ def statsusagechart(request):
         height=430,
         output_backend="svg",
         # transparent, so the figure sits on the page and follows the theme with it. theme.js
-        # colours the title, the axes, the legend and the zero line to match
+        # colours the axes, the gridlines, the legend, the names of the halves and the zero line
         background_fill_color=None,
         border_fill_color=None,
     )
 
-    plot.grid.visible = False
+    # the gridlines of one half are the ticks of that half alone, so they run across the frame and
+    # the day boundaries do not
+    plot.xgrid.visible = False
 
     # the bars of each half, in the order they stack away from the zero line
     bars: dict[str, list[Any]] = {}
@@ -860,14 +859,14 @@ def statsusagechart(request):
         )
 
     # The ticks of the two halves are the same line of code twice over, but they are not the same
-    # numbers: each half is scaled to its own peak, so a tick at the same height means about a
-    # hundred times more tasks above the axis than below it.
+    # numbers: each half is scaled to its own gridlines, so a tick at the same height means about
+    # a hundred times more tasks above the axis than below it.
     tickpositions = [0.0]
     ticklabels: dict[float | str, Any] = {0.0: "0"}
     for origin, direction in (("api", 1.0), ("web", -1.0)):
-        peak = peaks[origin]
-        unit = (1.0 - USAGE_ARM_SPLIT) / peak if peak else 0.0
-        for value in _usage_arm_ticks(peak)[1:]:
+        ticks = armticks[origin]
+        unit = (1.0 - USAGE_ARM_SPLIT) / ticks[-1] if ticks[-1] else 0.0
+        for value in ticks[1:]:
             position = direction * (USAGE_ARM_SPLIT + value * unit)
             tickpositions.append(position)
             ticklabels[position] = f"{value:,.0f}"
@@ -879,10 +878,27 @@ def statsusagechart(request):
     # rather than as the axis of either one.
     plot.add_layout(bokeh.models.Span(location=0.0, dimension="width", line_width=1.5))
 
-    # One legend for the pair, built from the bars of the upper half. It stays inside the frame,
-    # in the blank days the x range ends with: moved to the panel above the frame it left the
-    # frame no height at all, and the chart drew as a legend over an axis.
-    legend = bokeh.models.Legend(location="top_right", border_line_width=0)
+    # Each half names itself and its own peak, in the room its top gridline leaves. This is what
+    # keeps a reader from taking the two heights as comparable, so it is not decoration.
+    for origin, name, corner, offset in (("api", "API", "top_right", -6), ("web", "Web", "bottom_right", 6)):
+        plot.add_layout(
+            bokeh.models.Label(
+                x=bokeh.models.Node(target="frame", symbol=corner),
+                y=bokeh.models.Node(target="frame", symbol=corner),
+                x_offset=-6,
+                y_offset=offset,
+                text=f"{name} \u2014 peak {peaks[origin]:,.0f}/day",
+                text_align="right",
+                text_baseline="top" if origin == "api" else "bottom",
+                text_font_size="11px",
+                text_font_style="bold",
+            )
+        )
+
+    # One legend for the pair, built from the bars of the upper half. It lies along the top of the
+    # frame: moved to the panel above the frame it left the frame no height at all, and the chart
+    # drew as a legend over an axis.
+    legend = bokeh.models.Legend(location="top_left", orientation="horizontal", border_line_width=0)
     legend.items = [
         bokeh.models.LegendItem(label=label, renderers=[bar])
         for (_key, label, _color), bar in zip(USAGE_SERIES, bars["api"], strict=True)

--- a/static/js/queuepage/src/runnerstatus.test.js
+++ b/static/js/queuepage/src/runnerstatus.test.js
@@ -74,6 +74,26 @@ function loadPageModule(tag) {
     return import(`./runnerstatus.js?${tag}=${Date.now()}`);
 }
 
+/**
+ * A storage of the shape that the cache uses, holding its items in an object.
+ *
+ * Every group that reaches a storage takes one of these. The store and the cache must not read
+ * the storage of the process: node gives a working sessionStorage of its own, so a test would
+ * start from the record that the test before it wrote.
+ *
+ * `refuse` gives the storage of a browser that is set to refuse site data, which throws from each
+ * of these rather than giving null.
+ */
+function fakeStorage(items = {}, { refuse = false } = {}) {
+    const guard = () => { if (refuse) { throw new Error('refused'); } };
+    return {
+        items,
+        getItem: (key) => { guard(); return key in items ? items[key] : null; },
+        setItem: (key, value) => { guard(); items[key] = String(value); },
+        removeItem: (key) => { guard(); delete items[key]; },
+    };
+}
+
 const healthy = (overrides = {}) => ({
     stale: false,
     maintenance: false,
@@ -220,21 +240,40 @@ describe('runnerMessage', () => {
 describe('the store', () => {
     let bodies;
     let fetched;
+    let storage;
+    let stores;
 
     beforeEach(() => {
         fetched = [];
         bodies = [];
+        storage = fakeStorage();
+        stores = [];
         global.fetch = queuedFetch(bodies, fetched);
     });
 
     afterEach(() => {
+        // A failed assertion skips the unsubscribe at the end of its test, and the poll of that
+        // store then holds the process open. The suite reports nothing at all in that case: it
+        // runs to the end and then waits for a timer that no test can reach.
+        stores.forEach((store) => store.stop());
         delete global.fetch;
         mock.timers.reset();
     });
 
+    /**
+     * A store of the endpoint, on the empty storage of this test.
+     *
+     * Each store made here is stopped in afterEach, whether its test ended or failed.
+     */
+    const storeOf = (poll = 1000) => {
+        const store = createStore({ url: STATUS_URL, poll, storage });
+        stores.push(store);
+        return store;
+    };
+
     test('the first response reaches a subscriber', async () => {
         bodies.push({ body: healthy() });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
         const seen = [];
 
         const unsubscribe = store.subscribe((status) => seen.push(status));
@@ -249,7 +288,7 @@ describe('the store', () => {
 
     test('a subscriber that arrives later is told the current status at once', async () => {
         bodies.push({ body: healthy() });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
         const first = store.subscribe(() => {});
         await settle();
 
@@ -264,7 +303,7 @@ describe('the store', () => {
 
     test('a poll that says the same thing tells nobody', async () => {
         bodies.push({ body: healthy() }, { body: healthy({ written: '2026-01-01T00:01:00Z', status_age_seconds: 9 }) });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
         const seen = [];
         const unsubscribe = store.subscribe((status) => seen.push(status));
 
@@ -286,7 +325,7 @@ describe('the store', () => {
         // outage.
         const down = (age) => ({ body: { stale: true, queued_task_count: 1, status_age_seconds: age, typical_runtime_seconds: {} } });
         bodies.push(down(61), down(7200));
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
         const seen = [];
         const unsubscribe = store.subscribe((status) => seen.push(status));
 
@@ -305,7 +344,7 @@ describe('the store', () => {
         // not take a status code for an answer either way, so a release that still answers 503 is
         // read while it is being replaced.
         bodies.push({ status: 503, body: { stale: true, status_age_seconds: 300 } });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
         const seen = [];
         const unsubscribe = store.subscribe((status) => seen.push(status));
 
@@ -317,7 +356,7 @@ describe('the store', () => {
     test('an unreachable endpoint is not an outage, until it has been unreachable for a while', async () => {
         mock.timers.enable({ apis: ['setInterval', 'Date'] });
         bodies.push({ body: healthy() });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
         const seen = [];
         const unsubscribe = store.subscribe((status) => seen.push(status));
         await settle();
@@ -344,7 +383,7 @@ describe('the store', () => {
         const window = setupDom();
         try {
             bodies.push({ body: healthy() }, { body: healthy({ slots_busy: 9 }) });
-            const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+            const store = storeOf();
             const unsubscribe = store.subscribe(() => {});
             await settle();
             assert.equal(fetched.length, 1);
@@ -369,7 +408,7 @@ describe('the store', () => {
         try {
             window.user_is_active = false;
             bodies.push({ body: healthy() }, { body: healthy({ slots_busy: 9 }) });
-            const store = createStore({ url: '/taskrunnerstatus.json', poll: 100000 });
+            const store = storeOf(100000);
             unsubscribe = store.subscribe(() => {});
             await settle();
 
@@ -391,7 +430,7 @@ describe('the store', () => {
         try {
             window.user_is_active = false;
             bodies.push({ body: healthy() }, { body: healthy({ slots_busy: 9 }) });
-            const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+            const store = storeOf();
             unsubscribe = store.subscribe(() => {});
             await settle();
             assert.equal(fetched.length, 1, 'the first request fills the box either way');
@@ -416,7 +455,7 @@ describe('the store', () => {
             answers.push((slow) => resolve({ ok: true, status: 200, json: () => Promise.resolve(body) }));
         });
 
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 100000 });
+        const store = storeOf(100000);
         const unsubscribe = store.subscribe(() => {});
         store.refresh();
         await settle();
@@ -451,7 +490,7 @@ describe('the store', () => {
             });
         };
 
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 100000 });
+        const store = storeOf(100000);
         const unsubscribe = store.subscribe(() => {});
         try {
             store.refresh();
@@ -472,7 +511,7 @@ describe('the store', () => {
             answer = () => resolve({ ok: true, status: 200, json: () => Promise.resolve(healthy()) });
         });
 
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 100000 });
+        const store = storeOf(100000);
         store.subscribe(() => {})();
         answer();
         await settle();
@@ -485,7 +524,7 @@ describe('the store', () => {
         // first reader went to the catch of the fetch, which reads each exception as an endpoint
         // that it cannot reach. The queue page then had no status for the life of the page.
         bodies.push({ body: healthy() });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 100000 });
+        const store = storeOf(100000);
         const seen = [];
         const errors = [];
         const consoleError = console.error;
@@ -512,7 +551,7 @@ describe('the store', () => {
     test('the last reader to leave stops the poll', async () => {
         mock.timers.enable({ apis: ['setInterval', 'Date'] });
         bodies.push({ body: healthy() }, { body: healthy({ slots_busy: 9 }) });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
 
         const first = store.subscribe(() => {});
         const second = store.subscribe(() => {});
@@ -533,7 +572,7 @@ describe('the store', () => {
     test('unsubscribing twice does not stop a poll somebody else started', async () => {
         mock.timers.enable({ apis: ['setInterval', 'Date'] });
         bodies.push({ body: healthy() }, { body: healthy() }, { body: healthy() });
-        const store = createStore({ url: '/taskrunnerstatus.json', poll: 1000 });
+        const store = storeOf();
 
         const first = store.subscribe(() => {});
         first();
@@ -560,22 +599,6 @@ describe('the store', () => {
  * page that reaches sessionStorage itself is tested with the rest of the page load, below.
  */
 describe('the status kept for the next page', () => {
-    /**
-     * A storage of the shape that the cache uses, holding its items in an object.
-     *
-     * `refuse` gives the storage of a browser that is set to refuse site data, which throws from
-     * each of these rather than giving null.
-     */
-    function fakeStorage(items = {}, { refuse = false } = {}) {
-        const guard = () => { if (refuse) { throw new Error('refused'); } };
-        return {
-            items,
-            getItem: (key) => { guard(); return key in items ? items[key] : null; },
-            setItem: (key, value) => { guard(); items[key] = String(value); },
-            removeItem: (key) => { guard(); delete items[key]; },
-        };
-    }
-
     /**
      * The items of a storage holding a record as a page would have left it `ago` ms ago.
      *

--- a/static/js/queuepage/src/theme.test.js
+++ b/static/js/queuepage/src/theme.test.js
@@ -215,6 +215,108 @@ describe('theme.js', () => {
     });
   });
 
+  /*
+  The two stats charts. bokeh paints them into a canvas from the properties of the models it is
+  given, so their colours are set on those models rather than in the stylesheet: on the payload
+  the server sends, before the chart is built, and on the models of a chart already on screen.
+
+  Bootstrap is not here to write the custom properties the colours are read from, so the test
+  writes them onto <html> itself.
+  */
+  describe('the stats charts', () => {
+    const DARK = {
+      '--bs-body-color': '#dee2e6',
+      '--bs-border-color': '#495057',
+      '--bs-body-bg': '#212529'
+    };
+
+    const paintPage = (page, values) => {
+      for (const [property, value] of Object.entries(values)) {
+        page.window.document.documentElement.style.setProperty(property, value);
+      }
+    };
+
+    // a chart as the server sends it. bokeh writes each model as the name of its type and the
+    // properties that differ from the defaults, and an axis that is left at the defaults
+    // therefore arrives with no attributes at all
+    const item = () => ({
+      root_id: 'p1',
+      doc: {
+        roots: [
+          {
+            type: 'object',
+            name: 'Figure',
+            id: 'p1',
+            attributes: {
+              title: { type: 'object', name: 'Title', id: 'p2', attributes: { text: 'API' } },
+              below: [{ type: 'object', name: 'CategoricalAxis', id: 'p3' }],
+              renderers: [
+                {
+                  type: 'object',
+                  name: 'GlyphRenderer',
+                  id: 'p4',
+                  attributes: {
+                    glyph: { type: 'object', name: 'VBar', id: 'p5', attributes: { fill_color: 'red' } }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    });
+
+    const model = (type) => ({
+      type,
+      colors: {},
+      setv(attrs) {
+        Object.assign(this.colors, attrs);
+      }
+    });
+
+    test('the payload is coloured before bokeh builds the chart', async () => {
+      const page = await start({ systemDark: true });
+      paintPage(page, DARK);
+
+      const figure = page.window.atlasTheme.themeBokehItem(item()).doc.roots[0];
+
+      assert.equal(figure.attributes.outline_line_color, '#495057');
+      assert.equal(figure.attributes.title.attributes.text_color, '#dee2e6');
+      assert.equal(figure.attributes.below[0].attributes.major_label_text_color, '#dee2e6');
+      assert.equal(figure.attributes.below[0].attributes.axis_line_color, '#495057');
+    });
+
+    test('the colours that are the data are left alone', async () => {
+      const page = await start({ systemDark: true });
+      paintPage(page, DARK);
+
+      const figure = page.window.atlasTheme.themeBokehItem(item()).doc.roots[0];
+
+      assert.equal(figure.attributes.renderers[0].attributes.glyph.attributes.fill_color, 'red');
+    });
+
+    test('a chart on screen is recoloured when the mode changes', async () => {
+      const page = await start({ stored: 'light' });
+      const title = model('Title');
+      const bar = model('VBar');
+      page.window.Bokeh = { documents: [{ all_models: new Set([title, bar]) }] };
+
+      paintPage(page, DARK);
+      page.click('dark');
+
+      assert.equal(title.colors.text_color, '#dee2e6');
+      assert.deepEqual(bar.colors, {}, 'a type the chart theme does not name is left alone');
+    });
+
+    test('a page with no chart on it still changes mode', async () => {
+      const page = await start({ stored: 'light' });
+
+      page.click('dark');
+
+      assert.equal(page.theme(), 'dark');
+    });
+  });
+
   describe('when the system preference changes', () => {
     test('auto follows it', async () => {
       const page = await start({ systemDark: false });

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -164,6 +164,8 @@ whenever the mode changes so an existing plot or chart can be recoloured in plac
     var styles = getComputedStyle(document.documentElement);
     var textcolor = styles.getPropertyValue('--bs-body-color').trim() || '#212529';
     var linecolor = styles.getPropertyValue('--bs-border-color').trim() || '#DEE2E6';
+    // lighter than the rest: a gridline is read past rather than looked at
+    var gridcolor = styles.getPropertyValue('--bs-border-color-translucent').trim() || 'rgba(0, 0, 0, 0.175)';
 
     var axis = {
       axis_label_text_color: textcolor,
@@ -186,7 +188,7 @@ whenever the mode changes so an existing plot or chart can be recoloured in plac
       // the name of each half of the usage chart, in the corner of its own side
       Label: { text_color: textcolor },
       // the gridlines of the usage chart, and the zero line the two halves are mirrored about
-      Grid: { grid_line_color: linecolor },
+      Grid: { grid_line_color: gridcolor },
       Span: { line_color: linecolor },
       LinearAxis: axis,
       CategoricalAxis: axis
@@ -203,6 +205,23 @@ whenever the mode changes so an existing plot or chart can be recoloured in plac
   The page does this before it calls Bokeh.embed.embed_item, so bokeh draws the chart in the right
   colours the first time.
   */
+  /*
+  The properties of `attrs` that `current` has not turned off.
+
+  A chart says it wants no line by giving that line no colour: the usage chart has no box around
+  its frame and no rule along either axis. Without this the table below would colour those lines
+  in, and put them back.
+  */
+  function stillDrawn(attrs, current) {
+    var wanted = {};
+    Object.keys(attrs).forEach(function (property) {
+      if (current[property] !== null) {
+        wanted[property] = attrs[property];
+      }
+    });
+    return wanted;
+  }
+
   function themeBokehItem(item) {
     var colors = bokehColors();
 
@@ -215,7 +234,7 @@ whenever the mode changes so an existing plot or chart can be recoloured in plac
         return;
       }
       if (node.type === 'object' && colors[node.name]) {
-        node.attributes = Object.assign(node.attributes || {}, colors[node.name]);
+        node.attributes = Object.assign(node.attributes || {}, stillDrawn(colors[node.name], node.attributes || {}));
       }
       Object.keys(node).forEach(function (key) {
         paint(node[key]);
@@ -243,7 +262,7 @@ whenever the mode changes so an existing plot or chart can be recoloured in plac
     window.Bokeh.documents.forEach(function (doc) {
       doc.all_models.forEach(function (model) {
         if (colors[model.type]) {
-          model.setv(colors[model.type]);
+          model.setv(stillDrawn(colors[model.type], model));
         }
       });
     });

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -12,8 +12,9 @@ deferred or end-of-body script would let the browser paint a light page first an
 dark, which is a visible flash on every navigation.
 
 window.atlasTheme is the interface for the parts of the page that are drawn rather than styled:
-lightcurveplotly.js asks plotlyColors() for the colours to build a plot with, and the "atlas:theme"
-event fires whenever the mode changes so an existing plot can be recoloured in place.
+lightcurveplotly.js asks plotlyColors() for the colours to build a plot with, stats.html asks
+themeBokehItem() to colour a bokeh chart before it is built, and the "atlas:theme" event fires
+whenever the mode changes so an existing plot or chart can be recoloured in place.
 */
 
 (function () {
@@ -147,6 +148,104 @@ event fires whenever the mode changes so an existing plot can be recoloured in p
     });
   }
 
+  /*
+  Colours for the two stats charts. bokeh paints a chart into a canvas from the properties of the
+  models it is given, so -- as with the light curves -- the stylesheet cannot reach it.
+
+  The table is keyed by the bokeh model each set of properties belongs to. The two functions below
+  both work from it: one colours the models a response carries, the other the models of a chart
+  that is already drawn.
+
+  A figure is itself transparent (see forcephot/views.py) and sits on the page background, so only
+  its outline is named here. The colours of the bars and of the sky are the data, and views.py
+  keeps them with the data.
+  */
+  function bokehColors() {
+    var styles = getComputedStyle(document.documentElement);
+    var textcolor = styles.getPropertyValue('--bs-body-color').trim() || '#212529';
+    var linecolor = styles.getPropertyValue('--bs-border-color').trim() || '#DEE2E6';
+
+    var axis = {
+      axis_label_text_color: textcolor,
+      major_label_text_color: textcolor,
+      axis_line_color: linecolor,
+      major_tick_line_color: linecolor,
+      minor_tick_line_color: linecolor
+    };
+
+    return {
+      Figure: { outline_line_color: linecolor },
+      Title: { text_color: textcolor },
+      // the legend sits on a transparent figure, so the page background is what separates it from
+      // the bars behind it
+      Legend: {
+        label_text_color: textcolor,
+        background_fill_color: styles.getPropertyValue('--bs-body-bg').trim() || '#FFFFFF',
+        border_line_color: linecolor
+      },
+      // the zero line the two halves of the usage chart are mirrored about
+      Span: { line_color: linecolor },
+      LinearAxis: axis,
+      CategoricalAxis: axis
+    };
+  }
+
+  /*
+  Colour the models in the JSON of a statsusagechart or statscoordchart response.
+
+  bokeh writes a model as an object that gives the name of its type and the properties which
+  differ from the defaults. Each later mention of that model is its id alone. Thus the colours go
+  on the one object that carries `attributes`.
+
+  The page does this before it calls Bokeh.embed.embed_item, so bokeh draws the chart in the right
+  colours the first time.
+  */
+  function themeBokehItem(item) {
+    var colors = bokehColors();
+
+    (function paint(node) {
+      if (Array.isArray(node)) {
+        node.forEach(paint);
+        return;
+      }
+      if (node === null || typeof node !== 'object') {
+        return;
+      }
+      if (node.type === 'object' && colors[node.name]) {
+        node.attributes = Object.assign(node.attributes || {}, colors[node.name]);
+      }
+      Object.keys(node).forEach(function (key) {
+        paint(node[key]);
+      });
+    })(item);
+
+    return item;
+  }
+
+  /*
+  Recolour the stats charts that are already on screen. Every chart bokeh has built is a document
+  in Bokeh.documents. A change to a property redraws the part of the chart that shows it, and thus
+  keeps whatever the visitor has panned or zoomed to.
+
+  setv throws on a property that the model does not have, so a model is only given the properties
+  of its own type.
+  */
+  function recolourBokehCharts() {
+    if (!window.Bokeh || !window.Bokeh.documents) {
+      return;
+    }
+
+    var colors = bokehColors();
+
+    window.Bokeh.documents.forEach(function (doc) {
+      doc.all_models.forEach(function (model) {
+        if (colors[model.type]) {
+          model.setv(colors[model.type]);
+        }
+      });
+    });
+  }
+
   function applyMode(mode) {
     document.documentElement.setAttribute('data-bs-theme', resolve(mode));
     document.dispatchEvent(new CustomEvent('atlas:theme', { detail: { theme: currentTheme() } }));
@@ -191,6 +290,7 @@ event fires whenever the mode changes so an existing plot can be recoloured in p
     });
 
     document.addEventListener('atlas:theme', recolourPlots);
+    document.addEventListener('atlas:theme', recolourBokehCharts);
   }
 
   /*
@@ -204,7 +304,7 @@ event fires whenever the mode changes so an existing plot can be recoloured in p
     }
   }
 
-  window.atlasTheme = { current: currentTheme, plotlyColors: plotlyColors };
+  window.atlasTheme = { current: currentTheme, plotlyColors: plotlyColors, themeBokehItem: themeBokehItem };
 
   applyMode(chosenMode);
 

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -183,7 +183,10 @@ whenever the mode changes so an existing plot or chart can be recoloured in plac
         background_fill_color: styles.getPropertyValue('--bs-body-bg').trim() || '#FFFFFF',
         border_line_color: linecolor
       },
-      // the zero line the two halves of the usage chart are mirrored about
+      // the name of each half of the usage chart, in the corner of its own side
+      Label: { text_color: textcolor },
+      // the gridlines of the usage chart, and the zero line the two halves are mirrored about
+      Grid: { grid_line_color: linecolor },
       Span: { line_color: linecolor },
       LinearAxis: axis,
       CategoricalAxis: axis

--- a/static/main.css
+++ b/static/main.css
@@ -1431,10 +1431,6 @@ table.countrystats th[scope="row"] {
   font-weight: normal !important;
 }
 
-.bk-logo {
-  display: none !important;
-}
-
 /* The toolbar of the coordinate chart. bokeh draws each button as a mask that it fills with one
    colour, and it reads that colour from --bokeh-icon-color on the page. A grey of its own is used
    if the page does not set it, which on the dark theme is almost the background.

--- a/static/main.css
+++ b/static/main.css
@@ -1435,18 +1435,13 @@ table.countrystats th[scope="row"] {
   display: none !important;
 }
 
-/* The two stats charts are drawn by bokeh on the server, into a white figure with dark text, and
-   both endpoints are cached and served to every visitor alike -- so unlike the light curves, which
-   Plotly draws in the browser, they cannot be asked to follow a preference held in the browser.
-   They stay as they are and get a light card to sit on, so on the dark theme they read as panels
-   rather than as two bare white rectangles. */
-[data-bs-theme="dark"] #statsusagechart,
-[data-bs-theme="dark"] #statscoordchart {
-  background-color: #f8f9fa;
-  /* the "Loading..." placeholder and the message left behind if the fetch fails are ordinary text
-     in these containers, so they need the colour that goes with the card rather than the page's */
-  color: #212529;
-  border-radius: 0.5em;
+/* The toolbar of the coordinate chart. bokeh draws each button as a mask that it fills with one
+   colour, and it reads that colour from --bokeh-icon-color on the page. A grey of its own is used
+   if the page does not set it, which on the dark theme is almost the background.
+
+   This is all a stylesheet can reach: the chart itself is a canvas, which theme.js colours. */
+:root {
+  --bokeh-icon-color: var(--bs-secondary-color);
 }
 
 #submitrequest.submitting {


### PR DESCRIPTION
The two stats charts are drawn by bokeh into a white figure with dark text, and both endpoints are
cached and served to every visitor alike, so they could not follow a preference held in the browser.
They were given a light card to sit on, and on the dark theme they read as two pale panels.

## The colours are now taken in the browser

Both figures are transparent, and `theme.js` colours the title, the axes, the legend and the zero
line from the same Bootstrap custom properties the rest of the page uses. The endpoints send
`json_item` instead of `components`, so the page builds the chart with `Bokeh.embed.embed_item` and
the theme reaches the models before bokeh draws them. That also removes the `<script>` tag the page
used to rebuild and append to `<head>` at every chart load.

`--bokeh-icon-color` in `main.css` colours the coordinate chart's toolbar, which is the one part a
stylesheet can reach.

## The usage chart is one mirrored figure

The API is drawn above the day axis and the web below it, each half against its own peak, with one
legend and one row of day labels. Each half names its peak in the title, which with the per-half
tick labels is what keeps a reader from taking the two heights as comparable.

## The palette

| series | hex | was |
|---|---|---|
| Finished, photometry | `#3987e5` | `green` |
| Finished, images | `#199e70` | `blue` |
| Queued | `#c98500` | `red` |
| Attempted, unfinished | `#d03b3b` | *(new)* |

`#0000ff` measured 1.8:1 against the `#212529` dark page, below the 3:1 floor a filled mark needs,
and fell outside the lightness band for a dark surface. `red` beside `green` — the two largest
segments of every stack, touching — separates by only dE 7.0 under protanopia, where 8 is the floor.

One step of each new hue clears the lightness band, the chroma floor and the 3:1 contrast floor
against both the white page and the dark one, so the bars hold still while the frame follows the
theme. Amber and red, the pair that has to read as an escalation, separate by dE 19.8 light and 10.2
dark under deuteranopia.

## A fourth series

The unfinished tasks are split on `attempt_count`. A task the runner started and did not finish says
something about the server that a task waiting its turn does not, so it takes red, held apart from
the three hues that carry the ordinary series.

```python
unfinished = Task.objects.filter(timestamp__gt=windowstart, finishtimestamp__isnull=True)
queued  = unfinished.filter(attempt_count=0)       # amber
stalled = unfinished.filter(attempt_count__gte=1)  # red
```

## Also fixed here

A finished `SSOSTACK` task was counted by no series at all, while the unfinished series count a task
of any type — so a Solar System image stack sat in the waiting band and then vanished from the chart
when it finished, shrinking that day's total. The image series now covers every request type that is
not forced photometry.

## Notes for review

- `sizing_mode="stretch_width"` with a pixel height, not an aspect ratio: the container gives a
  width and no height, and bokeh solved the first layout against a ratio with a frame of no height
  at all.
- The legend stays inside the frame, in three blank day factors at the end of the x range. Moved to
  the panel above the frame with `add_layout(legend, "above")` it also left the frame no height.
- Each half starts a little off the zero line. Without that gap the two arms meet and a day reads as
  one bar through the axis.

## Testing

`./manage.py test` — 348 tests, including the queued/stalled split, the per-half scaling, the gap at
the zero line, and the tick ladder. `npm test` in `static/js/queuepage` — 207 tests, including four
new ones for the bokeh theming. Looked at on both themes against 65,000 tasks seeded from the live
per-day counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)